### PR TITLE
Refactoring - part 1

### DIFF
--- a/sonata/csv_lib.cpp
+++ b/sonata/csv_lib.cpp
@@ -74,14 +74,14 @@ csv_record::csv_record(std::vector<csv_file> files) {
     }
 }
 
-std::unordered_map<std::string, std::string> csv_record::fields(type_pop_id id) {
+std::unordered_map<std::string, std::string> csv_record::fields(type_pop_id id) const {
     if (fields_.find(id) != fields_.end()) {
-        return fields_[id];
+        return fields_.at(id);
     }
     throw sonata_exception("Requested CSV column not found");
 }
 
-std::vector<type_pop_id> csv_record::unique_ids() {
+std::vector<type_pop_id> csv_record::unique_ids() const {
     return ids_;
 }
 
@@ -214,7 +214,43 @@ csv_edge_record::csv_edge_record(std::vector<csv_file> files) : csv_record(files
     }
 }
 
-arb::mechanism_desc csv_edge_record::point_mech_desc(type_pop_id id) {
+std::vector<std::pair<std::string, std::string>> csv_edge_record::edge_to_source_of_target(std::string target_pop) const {
+    std::vector<std::pair<std::string, std::string>> edge_to_source;
+
+    for (auto id: ids_) {
+        const auto& type = fields(id);
+        if (type.at("target_pop_name") == target_pop) {
+            edge_to_source.emplace_back(std::make_pair(type.at("pop_name"), type.at("source_pop_name")));
+        }
+    }
+    return edge_to_source;
+}
+
+std::unordered_set<std::string> csv_edge_record::edges_of_target(std::string target_pop) const {
+    std::unordered_set<std::string> target_edge_pops;
+
+    for (auto id: ids_) {
+        const auto& type = fields(id);
+        if (type.at("target_pop_name") == target_pop) {
+            target_edge_pops.insert(type.at("pop_name"));
+        }
+    }
+    return target_edge_pops;
+}
+
+std::unordered_set<std::string> csv_edge_record::edges_of_source(std::string source_pop) const {
+    std::unordered_set<std::string> source_edge_pops;
+
+    for (auto id: ids_) {
+        const auto& type = fields(id);
+        if (type.at("source_pop_name") == source_pop) {
+            source_edge_pops.insert(type.at("pop_name"));
+        }
+    }
+    return source_edge_pops;
+}
+
+arb::mechanism_desc csv_edge_record::point_mech_desc(type_pop_id id) const {
     if (point_params_.find(id) != point_params_.end()) {
         return point_params_.at(id);
     }

--- a/sonata/data_management_lib.cpp
+++ b/sonata/data_management_lib.cpp
@@ -79,7 +79,7 @@ void database::build_current_clamp_map(std::vector<current_clamp_info> current) 
                 auto params = param_map.at(i.first);
 
                 auto local_loc = i.second;
-                auto global_gid = globalize_cell({local_loc.gid, nodes_.map()[local_loc.population]});
+                auto global_gid = nodes_.globalize({local_loc.population, local_loc.gid});
 
                 current_clamps_[global_gid].emplace_back(params.dur, params.amp, params.delay, arb::segment_location(local_loc.seg, local_loc.pos));
             }
@@ -102,18 +102,19 @@ void database::build_source_and_target_maps(const std::vector<arb::group_descrip
             std::unordered_set<source_type> src_set;
             std::vector<std::pair<target_type, unsigned>> tgt_vec;
 
-            auto loc_node = localize_cell(gid);
-            auto source_edge_pops = edges_of_source(loc_node.pop_id);
-            auto target_edge_pops = edges_of_target(loc_node.pop_id);
+            auto loc_node = nodes_.localize(gid);
+            auto source_edge_pops = edge_types_.edges_of_source(loc_node.pop_name);
+            auto target_edge_pops = edge_types_.edges_of_target(loc_node.pop_name);
 
-            for (auto i: source_edge_pops) {
-                auto ind_id = edges_[i].find_group("indicies");
-                auto s2t_id = edges_[i][ind_id].find_group("source_to_target");
-                auto n2r_range = edges_[i][ind_id][s2t_id].int_pair_at("node_id_to_ranges", loc_node.el_id);
+            for (auto edge_pop_name: source_edge_pops) {
+                auto edge_pop = edges_.map()[edge_pop_name];
+                auto ind_id = edges_[edge_pop].find_group("indicies");
+                auto s2t_id = edges_[edge_pop][ind_id].find_group("source_to_target");
+                auto n2r_range = edges_[edge_pop][ind_id][s2t_id].int_pair_at("node_id_to_ranges", loc_node.el_id);
 
                 for (auto j = n2r_range.first; j< n2r_range.second; j++) {
-                    auto r2e = edges_[i][ind_id][s2t_id].int_pair_at("range_to_edge_id", j);
-                    auto src_rng = source_range(i, r2e);
+                    auto r2e = edges_[edge_pop][ind_id][s2t_id].int_pair_at("range_to_edge_id", j);
+                    auto src_rng = source_range(edge_pop, r2e);
                     for (auto s: src_rng) {
                         auto loc = src_set.find(s);
                         if (loc == src_set.end()) {
@@ -123,20 +124,22 @@ void database::build_source_and_target_maps(const std::vector<arb::group_descrip
                 }
             }
 
-            for (auto i: target_edge_pops) {
-                auto ind_id = edges_[i].find_group("indicies");
-                auto t2s_id = edges_[i][ind_id].find_group("target_to_source");
-                auto n2r = edges_[i][ind_id][t2s_id].int_pair_at("node_id_to_ranges", loc_node.el_id);
-                for (auto j = n2r.first; j< n2r.second; j++) {
-                    auto r2e = edges_[i][ind_id][t2s_id].int_pair_at("range_to_edge_id", j);
+            for (auto edge_pop_name: target_edge_pops) {
+                auto edge_pop = edges_.map()[edge_pop_name];
 
-                    auto tgt_rng = target_range(i, r2e);
+                auto ind_id = edges_[edge_pop].find_group("indicies");
+                auto t2s_id = edges_[edge_pop][ind_id].find_group("target_to_source");
+                auto n2r = edges_[edge_pop][ind_id][t2s_id].int_pair_at("node_id_to_ranges", loc_node.el_id);
+                for (auto j = n2r.first; j< n2r.second; j++) {
+                    auto r2e = edges_[edge_pop][ind_id][t2s_id].int_pair_at("range_to_edge_id", j);
+
+                    auto tgt_rng = target_range(edge_pop, r2e);
 
                     std::vector<unsigned> edge_rng(r2e.second - r2e.first);
                     std::iota(edge_rng.begin(), edge_rng.end(), r2e.first);
 
                     for (unsigned k = 0; k < tgt_rng.size(); k++) {
-                        tgt_vec.push_back(std::make_pair(tgt_rng[k], globalize_edge({i, (cell_gid_type)edge_rng[k]})));
+                        tgt_vec.push_back(std::make_pair(tgt_rng[k], edges_.globalize({edge_pop_name, (cell_gid_type)edge_rng[k]})));
                     }
                 }
             }
@@ -188,12 +191,15 @@ void database::build_source_and_target_maps(const std::vector<arb::group_descrip
 
 void database::get_connections(cell_gid_type gid, std::vector<arb::cell_connection>& conns) {
     // Find cell local index in population
-    auto loc_node = localize_cell(gid);
-    auto edge_to_source = edge_to_source_of_target(loc_node.pop_id);
+    auto loc_node = nodes_.localize(gid);
+    auto edge_to_source = edge_types_.edge_to_source_of_target(loc_node.pop_name);
 
     for (auto i: edge_to_source) {
-        auto edge_pop = i.first;
-        auto source_pop = i.second;
+        auto source_pop_name = i.second;
+        auto edge_pop_name = i.first;
+
+        auto edge_pop = edges_.map()[i.first];
+        auto source_pop = nodes_.map()[i.second];
 
         auto ind_id = edges_[edge_pop].find_group("indicies");
         auto s2t_id = edges_[edge_pop][ind_id].find_group("target_to_source");
@@ -211,7 +217,7 @@ void database::get_connections(cell_gid_type gid, std::vector<arb::cell_connecti
             std::vector<cell_member_type> sources, targets;
 
             for(unsigned s = 0; s < src_rng.size(); s++) {
-                auto source_gid = globalize_cell({source_pop, (cell_gid_type)src_id[s]});
+                auto source_gid = nodes_.globalize({source_pop_name, (cell_gid_type)src_id[s]});
 
                 auto loc = std::lower_bound(source_maps_[source_gid].begin(), source_maps_[source_gid].end(), src_rng[s],
                                             [](const auto& lhs, const auto& rhs) -> bool
@@ -237,14 +243,14 @@ void database::get_connections(cell_gid_type gid, std::vector<arb::cell_connecti
             unsigned e = 0;
             for(unsigned t = r2e.first; t < r2e.second; t++, e++) {
                 auto loc = std::lower_bound(target_maps_[gid].begin(), target_maps_[gid].end(),
-                                            std::make_pair(tgt_rng[e], globalize_edge({edge_pop, (cell_gid_type)t})),
+                                            std::make_pair(tgt_rng[e], edges_.globalize({edge_pop_name, (cell_gid_type)t})),
                                             [](const auto& lhs, const auto& rhs) -> bool
                                             {
                                                 return lhs.second < rhs.second;
                                             });
 
                 if (loc != target_maps_[gid].end()) {
-                    if ((*loc).second == globalize_edge({edge_pop, (cell_gid_type)t})) {
+                    if ((*loc).second == edges_.globalize({edge_pop_name, (cell_gid_type)t})) {
                         unsigned index = loc - target_maps_[gid].begin();
                         targets.push_back({gid, index});
                     }
@@ -279,15 +285,15 @@ void database::get_sources_and_targets(cell_gid_type gid,
 }
 
 arb::morphology database::get_cell_morphology(cell_gid_type gid) {
-    auto loc_node = localize_cell(gid);
-    auto node_pop_id = loc_node.pop_id;
+    auto loc_node = nodes_.localize(gid);
+    auto node_pop_name = loc_node.pop_name;
+    auto node_pop_id = nodes_.map()[node_pop_name];
     auto node_id = loc_node.el_id;
 
     auto group_id = nodes_[node_pop_id].int_at("node_group_id", node_id);
     auto group_idx = nodes_[node_pop_id].int_at("node_group_index", node_id);
 
     auto node_type_tag = nodes_[node_pop_id].int_at("node_type_id", node_id);
-    auto node_pop_name = nodes_[node_pop_id].name();
 
     if (nodes_[node_pop_id].find_group(std::to_string(group_id)) != -1) {
         auto lgi = nodes_[node_pop_id].find_group(std::to_string(group_id));
@@ -304,19 +310,20 @@ arb::morphology database::get_cell_morphology(cell_gid_type gid) {
 }
 
 arb::cell_kind database::get_cell_kind(cell_gid_type gid) {
-    auto loc_node = localize_cell(gid);
-    auto node_pop_id = loc_node.pop_id;
+    auto loc_node = nodes_.localize(gid);
+    auto node_pop_name = loc_node.pop_name;
+    auto node_pop_id = nodes_.map()[node_pop_name];
     auto node_id = loc_node.el_id;
 
     auto node_type_tag = nodes_[node_pop_id].int_at("node_type_id", node_id);
-    auto node_pop_name = nodes_[node_pop_id].name();
 
     return node_types_.cell_kind(type_pop_id(node_type_tag, node_pop_name));
 }
 
 std::unordered_map<std::string, std::vector<arb::mechanism_desc>> database::get_density_mechs(cell_gid_type gid) {
-    auto loc_node = localize_cell(gid);
-    auto node_pop_id = loc_node.pop_id;
+    auto loc_node = nodes_.localize(gid);
+    auto node_pop_name = loc_node.pop_name;
+    auto node_pop_id = nodes_.map()[node_pop_name];
     auto node_id = loc_node.el_id;
 
     auto nodes_grp_id = nodes_[node_pop_id].int_at("node_group_id", node_id);
@@ -356,10 +363,10 @@ std::unordered_map<std::string, std::vector<arb::mechanism_desc>> database::get_
 std::vector<double> database::get_spikes(cell_gid_type gid) {
     std::vector<double> spike_times;
 
-    auto loc_cell = localize_cell(gid);
+    auto loc_cell = nodes_.localize(gid);
 
     for (auto sp: spikes_) {
-        if (nodes_[loc_cell.pop_id].name() != sp.population) {
+        if (loc_cell.pop_name != sp.population) {
             continue;
         }
 

--- a/sonata/hdf5_lib.cpp
+++ b/sonata/hdf5_lib.cpp
@@ -527,6 +527,19 @@ bool h5_record::verify_nodes() {
     return true;
 }
 
+local_element h5_record::localize(unsigned gid) const {
+    for (unsigned i = 0; i < partitions().size(); i++) {
+        if (gid < partitions()[i]) {
+            return {pop_names()[i-1], gid - partitions()[i-1]};
+        }
+    }
+    return local_element();
+}
+
+unsigned h5_record::globalize(local_element n) const {
+    return n.el_id + partitions()[map_.at(n.pop_name)];
+}
+
 int h5_record::num_elements() const {
     return num_elements_;
 }

--- a/sonata/hdf5_lib.cpp
+++ b/sonata/hdf5_lib.cpp
@@ -459,6 +459,14 @@ const h5_wrapper& h5_wrapper::operator [](unsigned i) const {
     throw sonata_exception("h5_wrapper index out of range");
 }
 
+const h5_wrapper& h5_wrapper::operator [](std::string name) const {
+    auto gid = find_group(name);
+    if (gid != -1) {
+        return members_.at(gid);
+    }
+    throw sonata_exception("h5_wrapper index out of range");
+}
+
 std::string h5_wrapper::name() const {
     return ptr_->name();
 }
@@ -523,8 +531,11 @@ int h5_record::num_elements() const {
     return num_elements_;
 }
 
-const h5_wrapper& h5_record::operator [](std::string i) const {
-    return populations_[map_.at(i)];
+const h5_wrapper& h5_record::operator [](std::string name) const {
+    if (map_.find(name) == map_.end()) {
+        throw sonata_exception("population not present in hdf5 file");
+    }
+    return populations_[map_.at(name)];
 }
 
 const h5_wrapper& h5_record::operator [](int i) const {

--- a/sonata/include/csv_lib.hpp
+++ b/sonata/include/csv_lib.hpp
@@ -52,8 +52,8 @@ class csv_record {
 public:
     csv_record(std::vector<csv_file> files);
 
-    std::vector<type_pop_id> unique_ids();
-    std::unordered_map<std::string, std::string> fields(type_pop_id id);
+    std::vector<type_pop_id> unique_ids() const;
+    std::unordered_map<std::string, std::string> fields(type_pop_id id) const;
 
 protected:
     std::vector<type_pop_id> ids_;
@@ -93,8 +93,16 @@ class csv_edge_record : public csv_record {
 public:
     csv_edge_record(std::vector<csv_file> files);
 
-    arb::mechanism_desc point_mech_desc(type_pop_id id);
+    arb::mechanism_desc point_mech_desc(type_pop_id id) const;
 
+    // Given a target population, return a pair of edge populations and source populations that are connected to the target population
+    std::vector<std::pair<std::string, std::string>> edge_to_source_of_target(std::string target_pop) const;
+
+    // Given a target population, return all edge populations that are connected to the target population
+    std::unordered_set<std::string> edges_of_target(std::string target_pop) const;
+
+    // Given a source population, return all edge populations that are connected to the source population
+    std::unordered_set<std::string> edges_of_source(std::string source_pop) const;
 private:
 
     // Map from type_pop_id to point_mechanisms_desc

--- a/sonata/include/data_management_lib.hpp
+++ b/sonata/include/data_management_lib.hpp
@@ -58,9 +58,11 @@ public:
     cell_size_type num_cells() {
         return nodes_.num_elements();
     }
+
     cell_size_type num_edges() {
         return edges_.num_elements();
     }
+
     void build_source_and_target_maps(const std::vector<arb::group_description>&);
 
     void build_current_clamp_map(std::vector<current_clamp_info> current);
@@ -98,65 +100,6 @@ private:
     std::vector<double> weight_range(unsigned edge_pop_id, std::pair<unsigned, unsigned> edge_range);
     std::vector<double> delay_range(unsigned edge_pop_id, std::pair<unsigned, unsigned> edge_range);
 
-    /* Helper functions */
-    struct local_element{
-        cell_gid_type pop_id;
-        cell_gid_type el_id;
-    };
-
-    local_element localize_cell(cell_gid_type gid) {
-        unsigned i = 0;
-        for (; i < nodes_.partitions().size(); i++) {
-            if (gid < nodes_.partitions()[i]) {
-                return {i-1, gid - nodes_.partitions()[i-1]};
-            }
-        }
-        return local_element();
-    }
-
-    cell_gid_type globalize_cell(local_element n) {
-        return n.el_id + nodes_.partitions()[n.pop_id];
-    }
-
-    cell_gid_type globalize_edge(local_element e) {
-        return e.el_id + edges_.partitions()[e.pop_id];
-    }
-
-    std::unordered_map<unsigned, unsigned> edge_to_source_of_target(unsigned target_pop) {
-        std::unordered_map <unsigned, unsigned> edge_to_source;
-
-        for (auto id: edge_types_.unique_ids()) {
-            auto type = edge_types_.fields(id);
-            if (type["target_pop_name"] == nodes_[target_pop].name()) {
-                edge_to_source[edges_.map()[type["pop_name"]]] = nodes_.map()[type["source_pop_name"]];
-            }
-        }
-        return edge_to_source;
-    }
-
-    std::unordered_set<unsigned> edges_of_target(unsigned target_pop) {
-        std::unordered_set<unsigned> target_edge_pops;
-
-        for (auto id: edge_types_.unique_ids()) {
-            auto type = edge_types_.fields(id);
-            if (type["target_pop_name"] == nodes_[target_pop].name()) {
-                target_edge_pops.insert(edges_.map()[type["pop_name"]]);
-            }
-        }
-        return target_edge_pops;
-    }
-
-    std::unordered_set<unsigned> edges_of_source(unsigned source_pop) {
-        std::unordered_set<unsigned> source_edge_pops;
-
-        for (auto id: edge_types_.unique_ids()) {
-            auto type = edge_types_.fields(id);
-            if (type["source_pop_name"] == nodes_[source_pop].name()) {
-                source_edge_pops.insert(edges_.map()[type["pop_name"]]);
-            }
-        }
-        return source_edge_pops;
-    }
 
     h5_record nodes_;
     h5_record edges_;

--- a/sonata/include/hdf5_lib.hpp
+++ b/sonata/include/hdf5_lib.hpp
@@ -194,6 +194,11 @@ private:
     std::unordered_map<std::string, unsigned> member_map_;
 };
 
+struct local_element{
+    std::string pop_name;
+    unsigned el_id;
+};
+
 /// Class that stores sonata specific information about a collection of hdf5 files
 class h5_record {
 public:
@@ -205,6 +210,12 @@ public:
     // Verifies that the hdf5 files contain sonata node information
     bool verify_nodes();
 
+    // If gid < num_elements, return population and local id in population, otherwise return empty struct
+    local_element localize(unsigned gid) const;
+
+    // Given a population and local id in it, return gid
+    unsigned globalize(local_element n) const;
+
     // Returns total number of nodes/edges
     int num_elements() const;
 
@@ -214,6 +225,9 @@ public:
     // Returns the population at index `i` in populations_
     const h5_wrapper& operator [](int i) const;
 
+    // Returns names of all populations_
+    std::vector<std::string> pop_names() const;
+
     // Returns all populations
     std::vector<h5_wrapper> populations() const;
 
@@ -222,9 +236,6 @@ public:
 
     // Returns map_
     std::unordered_map<std::string, unsigned> map() const;
-
-    // Returns names of all populations_
-    std::vector<std::string> pop_names() const;
 
 private:
     // Total number of nodes/ edges

--- a/sonata/include/hdf5_lib.hpp
+++ b/sonata/include/hdf5_lib.hpp
@@ -174,8 +174,11 @@ public:
     // Returns h5_wrapper of group at index i in members_
     const h5_wrapper& operator[] (unsigned i) const;
 
+    // Returns h5_wrapper of group with name `name` in members_
+    const h5_wrapper& operator[] (std::string name) const;
+
     // Returns name of the wrapped h5_group
-    std::string name() const ;
+    std::string name() const;
 
 private:
     // Pointer to the h5_group wrapped in h5_wrapper

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(unit_sources
     test_csv.cpp
     test_hdf5.cpp
+    test_databse.cpp
 
     # unit test driver
     test.cpp

--- a/test/unit/inputs/edges.csv
+++ b/test/unit/inputs/edges.csv
@@ -1,5 +1,5 @@
 edge_type_id,pop_name,source_pop_name,target_pop_name,model_template,dynamics_params,delay,syn_weight,afferent_section_id,afferent_section_pos,efferent_section_id,efferent_section_pos,threshold
-100,pop_e_e,pop_e,pop_e,expsyn,/home/abiakarn/git/arbor-sonata/example/components/point_params/expsyn.json,0.1,0.01,1,0.9,1,0.2,10
+105,pop_e_e,pop_e,pop_e,expsyn,/home/abiakarn/git/arbor-sonata/example/components/point_params/expsyn.json,0.1,0.01,1,0.9,1,0.2,10
 101,pop_i_e,pop_i,pop_e,expsyn,/home/abiakarn/git/arbor-sonata/example/components/point_params/expsyn.json,0.1,-0.01,0,0.2,0,0.9,10
 102,pop_i_i,pop_i,pop_i,expsyn,/home/abiakarn/git/arbor-sonata/example/components/point_params/expsyn.json,0.1,-0.01,1,0.2,0,0.5,10
 103,pop_e_i,pop_e,pop_i,expsyn,/home/abiakarn/git/arbor-sonata/example/components/point_params/expsyn.json,0.1,0.01,0,0.5,0,0.9,10

--- a/test/unit/inputs/gen_edges.py
+++ b/test/unit/inputs/gen_edges.py
@@ -3,141 +3,127 @@ import h5py
 f0 = h5py.File("edges_0.h5", "a")
 f1 = h5py.File("edges_1.h5", "a")
 f2 = h5py.File("edges_2.h5", "a")
-f3 = h5py.File("edges_3.h5", "a")
 
 edges0 = f0.create_group("edges")
 edges1 = f1.create_group("edges")
 edges2 = f2.create_group("edges")
-edges3 = f3.create_group("edges")
 
-pop_e_e = edges0.create_group("pop_e_e")
+pop_e_i = edges0.create_group("pop_e_i")
 pop_i_e = edges1.create_group("pop_i_e")
-pop_i_i = edges2.create_group("pop_i_i")
-pop_e_i = edges3.create_group("pop_e_i")
+pop_e_e = edges2.create_group("pop_e_e")
 
-#################################################################################
-nedges = 20
-ntgts = 5
-nsrcs = 5
-s2t_ratio = nsrcs//ntgts #1
-nedges_per_tgt = nedges//ntgts #4
-nedges_per_src = nedges//nsrcs #4
+##################################################################################
+nedges = 2
+nsrcs = 4
+ntgts = 1
 
-edge_group_id = pop_e_e.create_dataset("edge_group_id", (nedges,), dtype="i")
-for i in range(0,nedges):
-    edge_group_id[i] = 0
+edge_group_id = pop_e_i.create_dataset("edge_group_id", (nedges,), dtype="i")
+edge_group_id[0] = 0
+edge_group_id[1] = 0
 
-edge_group_index = pop_e_e.create_dataset("edge_group_index", (nedges,), dtype="i")
-for i in range(0,nedges):
-    edge_group_index[i] = i
+edge_group_index = pop_e_i.create_dataset("edge_group_index", (nedges,), dtype="i")
+edge_group_index[0] = 0
+edge_group_index[1] = 1
 
-edge_type_id = pop_e_e.create_dataset("edge_type_id", (nedges,), dtype="i")
-for i in range(0,nedges):
-    edge_type_id[i] = 100
+edge_type_id = pop_e_i.create_dataset("edge_type_id", (nedges,), dtype="i")
+edge_type_id[0] = 103
+edge_type_id[1] = 103
 
-source_node_id = pop_e_e.create_dataset("source_node_id", (nedges,), dtype="i")
-for i in range(0,nsrcs):
-    for j in range(0,nedges_per_src):
-        source_node_id[i*nedges_per_src + j] = (i + j + 1) % nsrcs
+source_node_id = pop_e_i.create_dataset("source_node_id", (nedges,), dtype="i")
+source_node_id[0] = 0
+source_node_id[1] = 2
 
-target_node_id = pop_e_e.create_dataset("target_node_id", (nedges,), dtype="i")
-for i in range(0,ntgts):
-    for j in range(0,nedges_per_tgt):
-        target_node_id[i*nedges_per_tgt + j] = i
+target_node_id = pop_e_i.create_dataset("target_node_id", (nedges,), dtype="i")
+target_node_id[0] = 0
+target_node_id[1] = 0
 
-ind = pop_e_e.create_group("indicies")
+
+ind = pop_e_i.create_group("indicies")
 source_to_target = ind.create_group("source_to_target")
 
 node_id_to_ranges = source_to_target.create_dataset("node_id_to_ranges", (nsrcs,2), dtype="i")
-for i in range(0,nsrcs):
-    node_id_to_ranges[i] = i*nedges_per_src, (i+1)*nedges_per_src
+node_id_to_ranges[0] = 0,1
+node_id_to_ranges[1] = 1,1
+node_id_to_ranges[2] = 1,2
+node_id_to_ranges[3] = 2,2
 
-range_to_edge_id = source_to_target.create_dataset("range_to_edge_id", (nedges,2), dtype="i")
-for i in range(0,nsrcs):
-    for j in range(0, nedges_per_src):
-        t = (i - j + nsrcs - 1)%nsrcs
-        range_to_edge_id[i*nedges_per_src + j] = t*nedges_per_src + j, t*nedges_per_src + j + 1
-         
+range_to_edge_id = source_to_target.create_dataset("range_to_edge_id", (2,2), dtype="i")
+range_to_edge_id[0] = 0,1
+range_to_edge_id[1] = 1,2
+
 target_to_source = ind.create_group("target_to_source")
 
 node_id_to_ranges = target_to_source.create_dataset("node_id_to_ranges", (ntgts,2), dtype="i")
-for i in range(0,ntgts):
-    node_id_to_ranges[i] = i, i+1
+node_id_to_ranges[0] = 0,1
 
-range_to_edge_id = target_to_source.create_dataset("range_to_edge_id", (ntgts,2), dtype="i")
-for i in range(0,ntgts):
-    range_to_edge_id[i] = i*nedges_per_tgt, (i+1)*nedges_per_tgt
+range_to_edge_id = target_to_source.create_dataset("range_to_edge_id", (1,2), dtype="i")
+range_to_edge_id[0] = 0,2
 
 
+g0 = pop_e_i.create_group("0")
+g1 = pop_e_i.create_group("1")
 
-g0 = pop_e_e.create_group("0")
+afferent_id = g0.create_dataset("afferent_section_id", (1,), dtype="i")
+afferent_pos = g0.create_dataset("afferent_section_pos", (1,), dtype="f")
+efferent_id = g0.create_dataset("efferent_section_id", (1,), dtype="i")
+efferent_pos = g0.create_dataset("efferent_section_pos", (1,), dtype="f")
 
-afferent_id = g0.create_dataset("afferent_section_id", (nedges,), dtype="i")
-afferent_pos = g0.create_dataset("afferent_section_pos", (nedges,), dtype="f")
-efferent_id = g0.create_dataset("efferent_section_id", (nedges,), dtype="i")
-efferent_pos = g0.create_dataset("efferent_section_pos", (nedges,), dtype="f")
+afferent_id[0] = 0
+afferent_pos[0] = 0.4
+efferent_id[0] = 1
+efferent_pos[0] = 0.3
 
-for i in range(0,nedges):
-    afferent_id[i] = 0
-    afferent_pos[i] = 0.5
-    efferent_id[i] = 0
-    efferent_pos[i] = 0.9
+afferent_id = g1.create_dataset("afferent_section_id", (1,), dtype="i")
+afferent_pos = g1.create_dataset("afferent_section_pos", (1,), dtype="f")
+efferent_id = g1.create_dataset("efferent_section_id", (1,), dtype="i")
+efferent_pos = g1.create_dataset("efferent_section_pos", (1,), dtype="f")
 
-##################################################################################
-nedges = 2000
-ntgts = 400
-nsrcs = 100
-t2s_ratio = ntgts//nsrcs #4
-nedges_per_tgt = nedges//ntgts #5
-nedges_per_src = nedges//nsrcs #20 
+afferent_id[0] = 2
+afferent_pos[0] = 0.1
+efferent_id[0] = 3
+efferent_pos[0] = 0.2
+
+
+#################################################################################
+nedges = 1
+nsrcs = 1
+ntgts = 4
 
 edge_group_id = pop_i_e.create_dataset("edge_group_id", (nedges,), dtype="i")
-for i in range(0,nedges):
-    edge_group_id[i] = 0
+edge_group_id[0] = 0
 
 edge_group_index = pop_i_e.create_dataset("edge_group_index", (nedges,), dtype="i")
-for i in range(0,nedges):
-    edge_group_index[i] = i
+edge_group_index[0] = 0
 
 edge_type_id = pop_i_e.create_dataset("edge_type_id", (nedges,), dtype="i")
-for i in range(0,nedges):
-    edge_type_id[i] = 101
+edge_type_id[0] = 101
 
 source_node_id = pop_i_e.create_dataset("source_node_id", (nedges,), dtype="i")
-for i in range(0,ntgts):
-    for j in range(0,nedges_per_tgt):
-        source_node_id[i*nedges_per_tgt + j] = (i + j) % nsrcs 
+source_node_id[0] = 0
 
 target_node_id = pop_i_e.create_dataset("target_node_id", (nedges,), dtype="i")
-for i in range(0,ntgts):
-    for j in range(0,nedges_per_tgt):
-        target_node_id[i*nedges_per_tgt + j] = i
+target_node_id[0] = 1
 
 
 ind = pop_i_e.create_group("indicies")
 source_to_target = ind.create_group("source_to_target")
 
 node_id_to_ranges = source_to_target.create_dataset("node_id_to_ranges", (nsrcs,2), dtype="i")
-for i in range(0,nsrcs):
-    node_id_to_ranges[i] = i*nedges_per_src, (i+1)*nedges_per_src
+node_id_to_ranges[0] = 0, 1
 
-range_to_edge_id = source_to_target.create_dataset("range_to_edge_id", (nedges,2), dtype="i")
-#needs to be split in 3
-for i in range(0,nsrcs):
-    for j in range(0, t2s_ratio):
-        for k in range(0, nedges_per_tgt):
-            t = (i- k)%nsrcs + (j*nsrcs)
-            range_to_edge_id[i*t2s_ratio*nedges_per_tgt + j*nedges_per_tgt + k] = t*nedges_per_tgt + k, t*nedges_per_tgt + k + 1
+range_to_edge_id = source_to_target.create_dataset("range_to_edge_id", (1,2), dtype="i")
+range_to_edge_id[0] = 0, 1
          
 target_to_source = ind.create_group("target_to_source")
 
 node_id_to_ranges = target_to_source.create_dataset("node_id_to_ranges", (ntgts,2), dtype="i")
-for i in range(0,ntgts):
-    node_id_to_ranges[i] = i, i+1
+node_id_to_ranges[0] = 0, 0
+node_id_to_ranges[1] = 0, 1
+node_id_to_ranges[2] = 1, 1
+node_id_to_ranges[3] = 1, 1
 
-range_to_edge_id = target_to_source.create_dataset("range_to_edge_id", (ntgts,2), dtype="i")
-for i in range(0,ntgts):
-    range_to_edge_id[i] = i*nedges_per_tgt, (i+1)*nedges_per_tgt
+range_to_edge_id = target_to_source.create_dataset("range_to_edge_id", (1,2), dtype="i")
+range_to_edge_id[0] = 0, 1
 
 
 g0 = pop_i_e.create_group("0")
@@ -147,220 +133,68 @@ afferent_pos = g0.create_dataset("afferent_section_pos", (nedges,), dtype="f")
 efferent_id = g0.create_dataset("efferent_section_id", (nedges,), dtype="i")
 efferent_pos = g0.create_dataset("efferent_section_pos", (nedges,), dtype="f")
 
-for i in range(0,nedges):
-    afferent_id[i] = 0
-    afferent_pos[i] = 0.5
-    efferent_id[i] = 0
-    efferent_pos[i] = 0.9
+afferent_id[0] = 0
+afferent_pos[0] = 0.5
+efferent_id[0] = 0
+efferent_pos[0] = 0.9
 
 ##################################################################################
-nedges = 500
-ntgts = 100
-nsrcs = 100
-s2t_ratio = nsrcs//ntgts #1
-nedges_per_tgt = nedges//ntgts #5
-nedges_per_src = nedges//nsrcs #5
 
+nedges = 1
+nsrcs = 4
+ntgts = 4
 
-edge_group_id = pop_i_i.create_dataset("edge_group_id", (nedges,), dtype="i")
-for i in range(0,nedges):
-    edge_group_id[i] = 0
+edge_group_id = pop_e_e.create_dataset("edge_group_id", (nedges,), dtype="i")
+edge_group_id[0] = 0
 
-edge_group_index = pop_i_i.create_dataset("edge_group_index", (nedges,), dtype="i")
-for i in range(0,nedges):
-    edge_group_index[i] = i
+edge_group_index = pop_e_e.create_dataset("edge_group_index", (nedges,), dtype="i")
+edge_group_index[0] = 0
 
-edge_type_id = pop_i_i.create_dataset("edge_type_id", (nedges,), dtype="i")
-for i in range(0,nedges):
-    edge_type_id[i] = 102
+edge_type_id = pop_e_e.create_dataset("edge_type_id", (nedges,), dtype="i")
+edge_type_id[0] = 105
 
-source_node_id = pop_i_i.create_dataset("source_node_id", (nedges,), dtype="i")
-for i in range(0,nsrcs):
-    for j in range(0,nedges_per_src):
-        source_node_id[i*nedges_per_src + j] = (i + j + 1) % nsrcs 
+source_node_id = pop_e_e.create_dataset("source_node_id", (nedges,), dtype="i")
+source_node_id[0] = 1
 
-target_node_id = pop_i_i.create_dataset("target_node_id", (nedges,), dtype="i")
-for i in range(0,ntgts):
-    for j in range(0,nedges_per_tgt):
-        target_node_id[i*nedges_per_tgt + j] = i
+target_node_id = pop_e_e.create_dataset("target_node_id", (nedges,), dtype="i")
+target_node_id[0] = 3
 
-
-ind = pop_i_i.create_group("indicies")
+ind = pop_e_e.create_group("indicies")
 source_to_target = ind.create_group("source_to_target")
 
 node_id_to_ranges = source_to_target.create_dataset("node_id_to_ranges", (nsrcs,2), dtype="i")
-for i in range(0,nsrcs):
-    node_id_to_ranges[i] = i*nedges_per_src, (i+1)*nedges_per_src
+node_id_to_ranges[0] = 0,0
+node_id_to_ranges[1] = 0,1
+node_id_to_ranges[2] = 1,1
+node_id_to_ranges[3] = 1,1
 
-range_to_edge_id = source_to_target.create_dataset("range_to_edge_id", (nedges,2), dtype="i")
-for i in range(0,nsrcs):
-    for j in range(0, nedges_per_src):
-        t = (i - j + nsrcs - 1)%nsrcs
-        range_to_edge_id[i*nedges_per_src + j] = t*nedges_per_src + j, t*nedges_per_src + j + 1
-         
+range_to_edge_id = source_to_target.create_dataset("range_to_edge_id", (1,2), dtype="i")
+range_to_edge_id[0] = 0,1
+
 target_to_source = ind.create_group("target_to_source")
 
 node_id_to_ranges = target_to_source.create_dataset("node_id_to_ranges", (ntgts,2), dtype="i")
-for i in range(0,ntgts):
-    node_id_to_ranges[i] = i, i+1
+node_id_to_ranges[0] = 0,0
+node_id_to_ranges[1] = 0,0
+node_id_to_ranges[2] = 0,0
+node_id_to_ranges[3] = 0,1
 
-range_to_edge_id = target_to_source.create_dataset("range_to_edge_id", (ntgts,2), dtype="i")
-for i in range(0,ntgts):
-    range_to_edge_id[i] = i*nedges_per_tgt, (i+1)*nedges_per_tgt
+range_to_edge_id = target_to_source.create_dataset("range_to_edge_id", (1,2), dtype="i")
+range_to_edge_id[0] = 0,1
 
 
-g0 = pop_i_i.create_group("0")
+g0 = pop_e_e.create_group("0")
 
 afferent_id = g0.create_dataset("afferent_section_id", (nedges,), dtype="i")
 afferent_pos = g0.create_dataset("afferent_section_pos", (nedges,), dtype="f")
 efferent_id = g0.create_dataset("efferent_section_id", (nedges,), dtype="i")
 efferent_pos = g0.create_dataset("efferent_section_pos", (nedges,), dtype="f")
 
-for i in range(0,nedges):
-    afferent_id[i] = 0
-    afferent_pos[i] = 0.5
-    efferent_id[i] = 0
-    efferent_pos[i] = 0.9
+afferent_id[0] = 5
+afferent_pos[0] = 0.6
+efferent_id[0] = 1
+efferent_pos[0] = 0.2
 
-####################################### NOT PARAMETRIZABLE ##################################
-nedges = 2000
-ntgts = 100
-nsrcs = 400
-s2t_ratio = nsrcs//ntgts #4
-nedges_per_tgt = nedges//ntgts #20
-nedges_per_src = nedges//nsrcs #5
-
-edge_group_id = pop_e_i.create_dataset("edge_group_id", (nedges,), dtype="i")
-for i in range(0,nedges):
-    edge_group_id[i] = 0
-
-edge_group_index = pop_e_i.create_dataset("edge_group_index", (nedges,), dtype="i")
-for i in range(0,nedges):
-    edge_group_index[i] = i
-
-edge_type_id = pop_e_i.create_dataset("edge_type_id", (nedges,), dtype="i")
-for i in range(0,nedges):
-    edge_type_id[i] = 103
-
-source_node_id = pop_e_i.create_dataset("source_node_id", (nedges,), dtype="i")
-for i in range(0,ntgts):
-    for j in range (0,nedges_per_src):
-        for k in range(0,s2t_ratio):
-            src_start = i*s2t_ratio
-            source_node_id[i*nedges_per_src*s2t_ratio + j*s2t_ratio + k] = (src_start + k)
-
-target_node_id = pop_e_i.create_dataset("target_node_id", (nedges,), dtype="i")
-for i in range(0,ntgts):
-    for j in range(0,nedges_per_tgt):
-        target_node_id[i*nedges_per_tgt + j] = i
-
-
-ind = pop_e_i.create_group("indicies")
-source_to_target = ind.create_group("source_to_target")
-
-node_id_to_ranges = source_to_target.create_dataset("node_id_to_ranges", (nsrcs,2), dtype="i")
-for i in range(0,nsrcs):
-    node_id_to_ranges[i] = i*nedges_per_src, (i+1)*nedges_per_src
-
-range_to_edge_id = source_to_target.create_dataset("range_to_edge_id", (nedges,2), dtype="i")
-for i in range(0, ntgts):
-    for j in range(0, s2t_ratio):
-        for k in range(0, nedges_per_src):
-            start = j + k*s2t_ratio + i*s2t_ratio*nedges_per_src
-            range_to_edge_id[i*s2t_ratio*nedges_per_src + j*nedges_per_src + k] = start, start+1
-         
-target_to_source = ind.create_group("target_to_source")
-
-node_id_to_ranges = target_to_source.create_dataset("node_id_to_ranges", (ntgts,2), dtype="i")
-for i in range(0,ntgts):
-    node_id_to_ranges[i] = i, i+1
-
-range_to_edge_id = target_to_source.create_dataset("range_to_edge_id", (ntgts,2), dtype="i")
-for i in range(0,ntgts):
-    range_to_edge_id[i] = i*nedges_per_tgt, (i+1)*nedges_per_tgt
-
-
-g0 = pop_e_i.create_group("0")
-
-afferent_id = g0.create_dataset("afferent_section_id", (nedges,), dtype="i")
-afferent_pos = g0.create_dataset("afferent_section_pos", (nedges,), dtype="f")
-efferent_id = g0.create_dataset("efferent_section_id", (nedges,), dtype="i")
-efferent_pos = g0.create_dataset("efferent_section_pos", (nedges,), dtype="f")
-
-for i in range(0,nedges):
-    afferent_id[i] = 0
-    afferent_pos[i] = 0.5
-    efferent_id[i] = 0
-    efferent_pos[i] = 0.9
-
-##################################################################################
-
-nedges = 4
-ntgts = 400
-nsrcs = 5
-s2t_ratio = nsrcs//ntgts #1
-nedges_per_tgt = nedges//ntgts #1
-nedges_per_src = nedges//nsrcs #1
-
-edge_group_id = pop_ext_e.create_dataset("edge_group_id", (nedges,), dtype="i")
-for i in range(0,nedges):
-    edge_group_id[i] = 0
-
-edge_group_index = pop_ext_e.create_dataset("edge_group_index", (nedges,), dtype="i")
-for i in range(0,nedges):
-    edge_group_index[i] = i
-
-edge_type_id = pop_ext_e.create_dataset("edge_type_id", (nedges,), dtype="i")
-for i in range(0,nedges):
-    edge_type_id[i] = 200
-
-source_node_id = pop_ext_e.create_dataset("source_node_id", (nedges,), dtype="i")
-for i in range(0,nedges):
-    if i == 0:
-        source_node_id[i] = i
-    else : 
-        source_node_id[i] = i+1
-
-target_node_id = pop_ext_e.create_dataset("target_node_id", (nedges,), dtype="i")
-for i in range(0,nedges):
-    target_node_id[i] = i*100
-
-ind = pop_ext_e.create_group("indicies")
-source_to_target = ind.create_group("source_to_target")
-
-node_id_to_ranges = source_to_target.create_dataset("node_id_to_ranges", (nsrcs,2), dtype="i")
-for i in range(0,nsrcs):
-    if i == 0:
-        node_id_to_ranges[i] = i, i+1
-    if i == 1:
-        node_id_to_ranges[i] = i, i
-    if i > 1: 
-        node_id_to_ranges[i] = i-1, i
-
-range_to_edge_id = source_to_target.create_dataset("range_to_edge_id", (nedges,2), dtype="i")
-for i in range(0, nedges):
-    range_to_edge_id[i] = i, i+1
-         
-target_to_source = ind.create_group("target_to_source")
-
-node_id_to_ranges = target_to_source.create_dataset("node_id_to_ranges", (ntgts,2), dtype="i")
-start = 0
-end = 0
-for i in range(0,ntgts):
-    if i==0 or i==100 or i==200 or i==300: 
-        end = end + 1
-        node_id_to_ranges[i] = start, end
-        start = start + 1
-    else:
-        node_id_to_ranges[i] = start, end
-
-range_to_edge_id = target_to_source.create_dataset("range_to_edge_id", (nedges,2), dtype="i")
-for i in range(0,nedges):
-    range_to_edge_id[i] = i, i+1
-
-##################################################################################
 f0.close()
 f1.close()
-f2.close()
-f3.close()
-f4.close()
+f1.close()

--- a/test/unit/test_csv.cpp
+++ b/test/unit/test_csv.cpp
@@ -149,7 +149,7 @@ TEST(csv_edge_record, constructor) {
     auto f = csv_file(filename);
     auto r = csv_edge_record({f});
 
-    type_pop_id t0({100, "pop_e_e"});
+    type_pop_id t0({105, "pop_e_e"});
     type_pop_id t1({101, "pop_i_e"});
     type_pop_id t2({102, "pop_i_i"});
     type_pop_id t3({103, "pop_e_i"});

--- a/test/unit/test_databse.cpp
+++ b/test/unit/test_databse.cpp
@@ -49,7 +49,6 @@ TEST(database, helper_functions) {
     database db(nodes, edges, n_base, e_base, {}, {});
 
     EXPECT_EQ(5, db.num_cells());
-    EXPECT_EQ(4, db.num_edges());
 
     EXPECT_EQ(std::vector<unsigned>({0,4,5}), db.pop_partitions());
     EXPECT_EQ(std::vector<std::string>({"pop_e", "pop_i"}), db.pop_names());

--- a/test/unit/test_databse.cpp
+++ b/test/unit/test_databse.cpp
@@ -1,0 +1,70 @@
+#include <arbor/cable_cell.hpp>
+
+#include "hdf5_lib.hpp"
+#include "csv_lib.hpp"
+#include "data_management_lib.hpp"
+#include "sonata_exceptions.hpp"
+
+#include "../gtest.h"
+
+//                  ________________
+//                 |                v
+//  pop_e:  n0     n1      n2       n3
+//           |     ^       |
+//           |     |       |
+//           |     |       |
+//  pop_i:   |___> n5 <____|
+
+
+TEST(database, helper_functions) {
+    std::string datadir{DATADIR};
+
+    auto nodes0 = datadir + "/nodes_0.h5";
+    auto nodes1 = datadir + "/nodes_1.h5";
+
+    auto n0 = std::make_shared<h5_file>(nodes0);
+    auto n1 = std::make_shared<h5_file>(nodes1);
+
+    h5_record nodes({n0, n1});
+
+
+    auto edges0 = datadir + "/edges_0.h5";
+    auto edges1 = datadir + "/edges_1.h5";
+    auto edges2 = datadir + "/edges_2.h5";
+
+    auto e0 = std::make_shared<h5_file>(edges0);
+    auto e1 = std::make_shared<h5_file>(edges1);
+    auto e2 = std::make_shared<h5_file>(edges2);
+
+    h5_record edges({e0, e1, e2});
+
+    auto edges3 = datadir + "/edges.csv";
+    auto ef = csv_file(edges3);
+    auto e_base = csv_edge_record({ef});
+
+    auto nodes2 = datadir + "/nodes.csv";
+    auto nf = csv_file(nodes2);
+    auto n_base = csv_node_record({nf});
+
+    database db(nodes, edges, n_base, e_base, {}, {});
+
+    EXPECT_EQ(5, db.num_cells());
+    EXPECT_EQ(4, db.num_edges());
+
+    EXPECT_EQ(std::vector<unsigned>({0,4,5}), db.pop_partitions());
+    EXPECT_EQ(std::vector<std::string>({"pop_e", "pop_i"}), db.pop_names());
+
+    EXPECT_EQ("pop_e", db.population_of(0));
+    EXPECT_EQ("pop_e", db.population_of(1));
+    EXPECT_EQ("pop_e", db.population_of(2));
+    EXPECT_EQ("pop_e", db.population_of(3));
+    EXPECT_EQ("pop_i", db.population_of(4));
+
+//    auto l_cell = db.localize_cell(0);
+//    EXPECT_EQ(0, l_cell.pop_id);
+//    EXPECT_EQ(0, l_cell.el_id);
+//
+//    l_cell = db.localize_cell(4);
+//    EXPECT_EQ(1, l_cell.pop_id);
+//    EXPECT_EQ(0, l_cell.el_id);
+}

--- a/test/unit/test_hdf5.cpp
+++ b/test/unit/test_hdf5.cpp
@@ -5,6 +5,15 @@
 
 #include "../gtest.h"
 
+//                  ________________
+//                 |                v
+//  pop_e:  n0     n1      n2       n3
+//           |     ^       |
+//           |     |       |
+//           |     |       |
+//  pop_i:   |___> n5 <____|
+
+
 TEST(hdf5_record, verify_nodes) {
     std::string datadir{DATADIR};
 
@@ -18,15 +27,110 @@ TEST(hdf5_record, verify_nodes) {
 
     EXPECT_TRUE(r.verify_nodes());
     EXPECT_THROW(r.verify_edges(), sonata_exception);
+
+    EXPECT_EQ(std::vector<unsigned>({0u, 4u, 5u}), r.partitions());
+    EXPECT_EQ(5, r.num_elements());
+
+    auto pops = r.populations();
+    auto map = r.map();
+
+    EXPECT_EQ(pops.size(), 2);
+    EXPECT_EQ("pop_e", pops[0].name());
+    EXPECT_EQ("pop_i", pops[1].name());
+
+    EXPECT_EQ(0, map["pop_e"]);
+    EXPECT_EQ(1, map["pop_i"]);
+
+    EXPECT_EQ(r[0].name(), r["pop_e"].name());
+    EXPECT_EQ(r[1].name(), r["pop_i"].name());
 }
 
-TEST(hdf5_record, verify_nodes) {
+TEST(hdf5_record, verify_edges) {
     std::string datadir{DATADIR};
 
-    auto filename = datadir + "/nodes_0.h5";
-    auto f = std::make_shared<h5_file>(filename);
+    auto filename0 = datadir + "/edges_0.h5";
+    auto filename1 = datadir + "/edges_1.h5";
+    auto filename2 = datadir + "/edges_2.h5";
 
-    h5_record r({f});
+    auto f0 = std::make_shared<h5_file>(filename0);
+    auto f1 = std::make_shared<h5_file>(filename1);
+    auto f2 = std::make_shared<h5_file>(filename2);
 
-    EXPECT_TRUE(r.verify_nodes());
+    h5_record r({f0, f1, f2});
+
+    EXPECT_TRUE(r.verify_edges());
+    EXPECT_THROW(r.verify_nodes(), sonata_exception);
+
+    EXPECT_EQ(std::vector<unsigned>({0u, 2u, 3u, 4u}), r.partitions());
+    EXPECT_EQ(4, r.num_elements());
+
+    auto pops = r.populations();
+    auto map = r.map();
+
+    EXPECT_EQ(pops.size(), 3);
+    EXPECT_EQ("pop_e_i", pops[0].name());
+    EXPECT_EQ("pop_i_e", pops[1].name());
+    EXPECT_EQ("pop_e_e", pops[2].name());
+
+    EXPECT_EQ(0, map["pop_e_i"]);
+    EXPECT_EQ(1, map["pop_i_e"]);
+    EXPECT_EQ(2, map["pop_e_e"]);
+
+    EXPECT_EQ(r[0].name(), r["pop_e_i"].name());
+    EXPECT_EQ(r[1].name(), r["pop_i_e"].name());
+    EXPECT_EQ(r[2].name(), r["pop_e_e"].name());
+
+    EXPECT_EQ(2, r["pop_e_i"].dataset_size("edge_group_id"));
+    EXPECT_EQ(0, r["pop_e_i"].int_at("edge_group_id",0));
+    EXPECT_EQ(0, r["pop_e_i"].int_at("edge_group_id",1));
+
+    EXPECT_EQ(2, r["pop_e_i"].dataset_size("edge_group_index"));
+    EXPECT_EQ(0, r["pop_e_i"].int_at("edge_group_index",0));
+    EXPECT_EQ(1, r["pop_e_i"].int_at("edge_group_index",1));
+
+    EXPECT_EQ(2, r["pop_e_i"].dataset_size("edge_type_id"));
+    EXPECT_EQ(103, r["pop_e_i"].int_at("edge_type_id",0));
+    EXPECT_EQ(103, r["pop_e_i"].int_at("edge_type_id",1));
+
+    EXPECT_NE(-1, r["pop_e_i"].find_group("0"));
+    EXPECT_NE(-1, r["pop_e_i"].find_group("1"));
+
+    EXPECT_NE(-1, r["pop_i_e"].find_group("0"));
+    EXPECT_EQ(-1, r["pop_i_e"].find_group("1"));
+
+    EXPECT_NE(-1, r["pop_e_e"].find_group("0"));
+    EXPECT_EQ(-1, r["pop_e_e"].find_group("1"));
+
+    EXPECT_EQ(0,   r["pop_e_i"]["0"].int_at("afferent_section_id", 0));
+    EXPECT_NEAR(0.4, r["pop_e_i"]["0"].double_at("afferent_section_pos", 0), 1e-5);
+    EXPECT_EQ(1,   r["pop_e_i"]["0"].int_at("efferent_section_id", 0));
+    EXPECT_NEAR(0.3, r["pop_e_i"]["0"].double_at("efferent_section_pos", 0), 1e-5);
+
+    EXPECT_EQ(2,   r["pop_e_i"]["1"].int_at("afferent_section_id", 0));
+    EXPECT_NEAR(0.1, r["pop_e_i"]["1"].double_at("afferent_section_pos", 0), 1e-5);
+    EXPECT_EQ(3,   r["pop_e_i"]["1"].int_at("efferent_section_id", 0));
+    EXPECT_NEAR(0.2, r["pop_e_i"]["1"].double_at("efferent_section_pos", 0), 1e-5);
+
+    EXPECT_EQ(0,   r["pop_i_e"]["0"].int_at("afferent_section_id", 0));
+    EXPECT_NEAR(0.5, r["pop_i_e"]["0"].double_at("afferent_section_pos", 0), 1e-5);
+    EXPECT_EQ(0,   r["pop_i_e"]["0"].int_at("efferent_section_id", 0));
+    EXPECT_NEAR(0.9, r["pop_i_e"]["0"].double_at("efferent_section_pos", 0), 1e-5);
+
+    EXPECT_EQ(5,   r["pop_e_e"]["0"].int_at("afferent_section_id", 0));
+    EXPECT_NEAR(0.6, r["pop_e_e"]["0"].double_at("afferent_section_pos", 0), 1e-5);
+    EXPECT_EQ(1,   r["pop_e_e"]["0"].int_at("efferent_section_id", 0));
+    EXPECT_NEAR(0.2, r["pop_e_e"]["0"].double_at("efferent_section_pos", 0), 1e-5);
+
+    EXPECT_EQ(std::make_pair(0,1), r["pop_e_i"]["indicies"]["source_to_target"].int_pair_at("node_id_to_ranges", 0));
+    EXPECT_EQ(std::make_pair(1,1), r["pop_e_i"]["indicies"]["source_to_target"].int_pair_at("node_id_to_ranges", 1));
+    EXPECT_EQ(std::make_pair(1,2), r["pop_e_i"]["indicies"]["source_to_target"].int_pair_at("node_id_to_ranges", 2));
+    EXPECT_EQ(std::make_pair(2,2), r["pop_e_i"]["indicies"]["source_to_target"].int_pair_at("node_id_to_ranges", 3));
+
+    EXPECT_EQ(std::make_pair(0,1), r["pop_e_i"]["indicies"]["source_to_target"].int_pair_at("range_to_edge_id", 0));
+    EXPECT_EQ(std::make_pair(1,2), r["pop_e_i"]["indicies"]["source_to_target"].int_pair_at("range_to_edge_id", 1));
+
+    EXPECT_EQ(0, r["pop_e_i"].int_at("source_node_id", 0));
+    EXPECT_EQ(0, r["pop_e_i"].int_at("target_node_id", 0));
+    EXPECT_EQ(2, r["pop_e_i"].int_at("source_node_id", 1));
+    EXPECT_EQ(0, r["pop_e_i"].int_at("target_node_id", 1));
 }


### PR DESCRIPTION
As part of adding the unit tests, a lot of refactoring and code cleanup is taking place. Here we mainly try to separate the csv_lib functionalities and the hdf5_lib functionalities in a better way; cleanup the database class; and come up with a good small example to test in the unit tests. 