### PR TITLE
Override density parameters on a cell by cell basis - bug fix

### DIFF
--- a/sonata/csv_lib.cpp
+++ b/sonata/csv_lib.cpp
@@ -151,10 +151,23 @@ std::unordered_map<std::string, variable_map> csv_node_record::dynamic_params(ty
     return ret;
 }
 
-std::unordered_map<std::string, std::vector<arb::mechanism_desc>> csv_node_record::density_mech_desc(type_pop_id id) {
+std::unordered_map<std::string, std::vector<arb::mechanism_desc>> csv_node_record::density_mech_desc(
+        type_pop_id id, std::unordered_map<std::string, variable_map> override) {
     std::unordered_map<std::string, std::vector<arb::mechanism_desc>> ret;
 
     std::unordered_map<std::string, mech_groups> density_mechs = density_params_[id];
+
+    for (auto seg_overrides: override) {
+        if (density_mechs.find(seg_overrides.first) != density_mechs.end()) {
+            auto& base_id = density_mechs.at(seg_overrides.first);
+            auto& base_vars = base_id.variables;
+            for (auto var: seg_overrides.second) {
+                if (base_vars.find(var.first) != base_vars.end()) {
+                    base_vars[var.first] = var.second;
+                }
+            }
+        }
+    }
 
     // For every mech_id
     for (auto mech: density_mechs) {
@@ -186,7 +199,6 @@ void csv_node_record::override_density_params(type_pop_id id, std::unordered_map
         }
     }
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/sonata/data_management_lib.cpp
+++ b/sonata/data_management_lib.cpp
@@ -153,7 +153,7 @@ void database::build_source_and_target_maps(const std::vector<arb::group_descrip
     }
 }
 
-void database::read_spike_times(std::vector<spike_info> spikes) {
+void database::build_spike_map(std::vector<spike_info> spikes) {
     for (unsigned gid = 0; gid < num_cells(); gid++) {
         std::vector<double> spike_times;
 
@@ -180,7 +180,7 @@ void database::read_spike_times(std::vector<spike_info> spikes) {
     }
 }
 
-void database::read_current_clamps(std::vector<current_clamp_info> current) {
+void database::build_current_clamp_map(std::vector<current_clamp_info> current) {
 
     struct param_info {
         double dur;
@@ -442,8 +442,8 @@ std::unordered_map<std::string, std::vector<arb::mechanism_desc>> database::get_
             }
         }
     }
-    node_types_.override_density_params(node_unique_id, std::move(density_vars));
-    return node_types_.density_mech_desc(node_unique_id);
+
+    return node_types_.density_mech_desc(node_unique_id, std::move(density_vars));
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/sonata/include/csv_lib.hpp
+++ b/sonata/include/csv_lib.hpp
@@ -75,9 +75,9 @@ public:
     // Returns a map from mechanism names to list of variables and their overrides for a unique node
     std::unordered_map<std::string, variable_map> dynamic_params(type_pop_id id);
 
-    // Returns a map from mechanism names to mechanism decription for a unique node with
+    // Returns a map from section names to mechanism decriptions for a unique node with
     // parameter overrides applied
-    std::unordered_map<std::string, std::vector<arb::mechanism_desc>> density_mech_desc(type_pop_id id);
+    std::unordered_map<std::string, std::vector<arb::mechanism_desc>> density_mech_desc(type_pop_id id, std::unordered_map<std::string, variable_map> override = {});
 
     void override_density_params(type_pop_id id, std::unordered_map<std::string, variable_map> override);
 

--- a/sonata/include/data_management_lib.hpp
+++ b/sonata/include/data_management_lib.hpp
@@ -28,8 +28,8 @@ public:
              std::vector<spike_info> spikes,
              std::vector<current_clamp_info> current_clamp):
     nodes_(nodes), edges_(edges), node_types_(node_types), edge_types_(edge_types) {
-        read_spike_times(spikes);
-        read_current_clamps(current_clamp);
+        build_spike_map(spikes);
+        build_current_clamp_map(current_clamp);
     }
 
     /// Simple queries
@@ -59,9 +59,9 @@ public:
     // weight/delay of the connection and point mechanism with all parameters set
     void build_source_and_target_maps(const std::vector<arb::group_description>&);
 
-    void read_current_clamps(std::vector<current_clamp_info> current);
+    void build_current_clamp_map(std::vector<current_clamp_info> current);
 
-    void read_spike_times(std::vector<spike_info> spikes);
+    void build_spike_map(std::vector<spike_info> spikes);
 
     /// Read maps
 


### PR DESCRIPTION
Don't override base density parameters of a type-population. Every cell should inherit from the same base.