### PR TITLE
Refactoring - part 3

### DIFF
--- a/sonata/include/common_structs.hpp
+++ b/sonata/include/common_structs.hpp
@@ -14,23 +14,49 @@ using arb::cell_size_type;
 using arb::cell_member_type;
 using arb::segment_location;
 
+struct sim_conditions {
+    double temp_c;
+    double v_init;
+};
+
+struct run_params {
+    double duration;
+    double dt;
+    double threshold;
+};
+
+struct probe_info {
+    std::string kind;
+    std::string population;
+    std::vector<unsigned> node_ids;
+    unsigned sec_id;
+    double sec_pos;
+
+    std::string file_name;
+};
+
 struct current_clamp_info {
     csv_file stim_params;
     csv_file stim_loc;
 };
 
-struct spike_info {
+struct spike_out_info {
+    std::string file_name;
+    std::string sort_by;
+};
+
+struct spike_in_info {
     h5_wrapper data;
     std::string population;
 };
 
-struct current_clamp {
+struct current_clamp_desc {
     double duration;
     double amplitude;
     double delay;
     arb::segment_location stim_loc;
 
-    current_clamp(double dur, double amp, double del, arb::segment_location loc):
+    current_clamp_desc(double dur, double amp, double del, arb::segment_location loc):
             duration(dur), amplitude(amp), delay(del), stim_loc(loc){}
 };
 
@@ -67,6 +93,14 @@ struct trace_info {
     double seg_pos;
 
     arb::trace_data<double> data;
+
+    trace_info() {};
+
+    trace_info(arb::cell_probe_address p) {
+        is_voltage = p.kind == arb::cell_probe_address::membrane_voltage;
+        seg_id = p.location.segment;
+        seg_pos = p.location.position;
+    };
 };
 
 

--- a/sonata/include/sonata_io.hpp
+++ b/sonata/include/sonata_io.hpp
@@ -39,38 +39,12 @@ struct network_params {
             : nodes(other.nodes), nodes_types(other.nodes_types), edges(other.edges), edges_types(other.edges_types) {}
 };
 
-struct sim_conditions {
-    double temp_c;
-    double v_init;
-};
-
-struct run_params {
-    double duration;
-    double dt;
-    double threshold;
-};
-
-struct spike_out_info {
-    std::string file_name;
-    std::string sort_by;
-};
-
-struct probe_info {
-    std::string kind;
-    std::string population;
-    std::vector<unsigned> node_ids;
-    unsigned sec_id;
-    double sec_pos;
-
-    std::string file_name;
-};
-
 struct sonata_params {
     network_params network;
     sim_conditions conditions;
     run_params run;
     std::vector<current_clamp_info> current_clamps;
-    std::vector<spike_info> spikes_input;
+    std::vector<spike_in_info> spikes_input;
     spike_out_info spike_output;
     std::vector<probe_info> probes_info;
 
@@ -78,7 +52,7 @@ struct sonata_params {
                   sim_conditions&& s,
                   run_params&& r,
                   std::vector<current_clamp_info>&& clamps,
-                  std::vector<spike_info>&& spikes,
+                  std::vector<spike_in_info>&& spikes,
                   spike_out_info&& output,
                   std::vector<probe_info>&& probes):
     network(std::move(n)),
@@ -177,9 +151,9 @@ std::vector<current_clamp_info> read_clamps(std::unordered_map<std::string, nloh
     return ret;
 }
 
-std::vector<spike_info> read_spikes(std::unordered_map<std::string, nlohmann::json>& spike_json, const nlohmann::json& node_set_json) {
+std::vector<spike_in_info> read_spikes(std::unordered_map<std::string, nlohmann::json>& spike_json, const nlohmann::json& node_set_json) {
     using sup::param_from_json;
-    std::vector<spike_info> ret;
+    std::vector<spike_in_info> ret;
 
     for (auto input: spike_json) {
         if (input.second["input_type"] == "spikes") {

--- a/sonata/include/sonata_recipe.hpp
+++ b/sonata/include/sonata_recipe.hpp
@@ -40,16 +40,18 @@ using arb::cell_probe_address;
 class sonata_recipe: public arb::recipe {
 public:
     sonata_recipe(sonata_params params):
-            database_(params.network.nodes,
-                      params.network.edges,
-                      params.network.nodes_types,
-                      params.network.edges_types,
-                      params.spikes_input,
-                      params.current_clamps),
+            model_desc_(params.network.nodes,
+                       params.network.edges,
+                       params.network.nodes_types,
+                       params.network.edges_types),
+            io_desc_(params.network.nodes,
+                        params.spikes_input,
+                        params.current_clamps,
+                        params.probes_info),
             run_params_(params.run),
             sim_cond_(params.conditions),
             probe_info_(params.probes_info),
-            num_cells_(database_.num_cells()) {}
+            num_cells_(model_desc_.num_cells()) {}
 
     cell_size_type num_cells() const override {
         return num_cells_;
@@ -57,7 +59,7 @@ public:
 
     void build_local_maps(const arb::domain_decomposition& decomp) {
         std::lock_guard<std::mutex> l(mtx_);
-        database_.build_source_and_target_maps(decomp.groups);
+        model_desc_.build_source_and_target_maps(decomp.groups);
     }
 
     arb::util::unique_any get_cell_description(cell_gid_type gid) const override {
@@ -66,10 +68,10 @@ public:
             std::vector<std::pair<arb::segment_location, arb::mechanism_desc>> tgt_types;
 
             std::lock_guard<std::mutex> l(mtx_);
-            auto morph = database_.get_cell_morphology(gid);
-            auto mechs = database_.get_density_mechs(gid);
+            auto morph = model_desc_.get_cell_morphology(gid);
+            auto mechs = model_desc_.get_density_mechs(gid);
 
-            database_.get_sources_and_targets(gid, src_locs, tgt_types);
+            model_desc_.get_sources_and_targets(gid, src_locs, tgt_types);
 
             std::vector<std::pair<arb::segment_location, double>> src_types;
             for (auto s: src_locs) {
@@ -78,7 +80,7 @@ public:
 
             auto cell = dummy_cell(morph, mechs, src_types, tgt_types);
 
-            auto stims = database_.get_current_clamps(gid);
+            auto stims = io_desc_.get_current_clamps(gid);
             for (auto s: stims) {
                 arb::i_clamp stim(s.delay, s.duration, s.amplitude);
                 cell.add_stimulus(s.stim_loc, stim);
@@ -88,31 +90,31 @@ public:
         }
         else if (get_cell_kind(gid) == cell_kind::spike_source) {
             std::lock_guard<std::mutex> l(mtx_);
-            std::vector<double> time_sequence = database_.get_spikes(gid);
+            std::vector<double> time_sequence = io_desc_.get_spikes(gid);
             return arb::util::unique_any(arb::spike_source_cell{arb::explicit_schedule(time_sequence)});
         }
     }
 
     cell_kind get_cell_kind(cell_gid_type gid) const override {
         std::lock_guard<std::mutex> l(mtx_);
-        return database_.get_cell_kind(gid);
+        return model_desc_.get_cell_kind(gid);
     }
 
     cell_size_type num_sources(cell_gid_type gid) const override {
         std::lock_guard<std::mutex> l(mtx_);
-        return database_.num_sources(gid);
+        return model_desc_.num_sources(gid);
     }
 
     cell_size_type num_targets(cell_gid_type gid) const override {
         std::lock_guard<std::mutex> l(mtx_);
-        return database_.num_targets(gid);
+        return model_desc_.num_targets(gid);
     }
 
     std::vector<arb::cell_connection> connections_on(cell_gid_type gid) const override {
         std::vector<arb::cell_connection> conns;
 
         std::lock_guard<std::mutex> l(mtx_);
-        database_.get_connections(gid, conns);
+        model_desc_.get_connections(gid, conns);
 
         return conns;
     }
@@ -123,51 +125,15 @@ public:
     }
 
     cell_size_type num_probes(cell_gid_type gid)  const override {
-        std::lock_guard<std::mutex> l(mtx_);
-        std::string population = database_.population_of(gid);
-
-        unsigned sum = 0;
-        for (auto p: probe_info_) {
-            if (population == p.population) {
-                if (p.node_ids.empty()) {
-                    sum++;
-                } else {
-                    if (std::binary_search(p.node_ids.begin(), p.node_ids.end(), database_.population_id_of(gid))) {
-                        sum++;
-                    }
-                }
-            }
-        }
-        return sum;
+        return io_desc_.get_num_probes(gid);
     }
 
     arb::probe_info get_probe(cell_member_type id) const override {
-        std::lock_guard<std::mutex> l(mtx_);
-        std::string population = database_.population_of(id.gid);
+        return io_desc_.get_probe(id);
+    }
 
-        unsigned loc = 0;
-        for (auto p: probe_info_) {
-            if (population == p.population) {
-                if (p.node_ids.empty() || std::binary_search(p.node_ids.begin(), p.node_ids.end(), database_.population_id_of(id.gid))) {
-                    if (loc == id.index) {
-                        // Get the appropriate kind for measuring voltage.
-                        cell_probe_address::probe_kind kind;
-                        if (p.kind == "v") {
-                            kind = cell_probe_address::membrane_voltage;
-                        } else if (p.kind == "i") {
-                            kind = cell_probe_address::membrane_current;
-                        } else {
-                            throw sonata_exception("Probe kind not supported");
-                        }
-                        arb::segment_location loc(p.sec_id, p.sec_pos);
-
-                        probe_files_[id] = p.file_name;
-                        return arb::probe_info{id, kind, cell_probe_address{loc, kind}};
-                    }
-                    loc++;
-                }
-            }
-        }
+    std::unordered_map<std::string, std::vector<cell_member_type>> get_probe_groups() {
+        return io_desc_.get_probe_groups();
     }
 
     arb::util::any get_global_properties(cell_kind k) const override {
@@ -177,26 +143,22 @@ public:
         return a;
     }
 
-    std::string get_probe_file(cell_member_type id) const {
-        return probe_files_[id];
-    }
-
     std::vector<unsigned> get_pop_partitions() const {
-        return database_.pop_partitions();
+        return model_desc_.pop_partitions();
     }
 
     std::vector<std::string> get_pop_names() const {
-        return database_.pop_names();
+        return model_desc_.pop_names();
     }
 
 private:
     mutable std::mutex mtx_;
-    mutable database database_;
+    mutable model_desc model_desc_;
+    mutable io_desc io_desc_;
 
     run_params run_params_;
     sim_conditions sim_cond_;
     std::vector<probe_info> probe_info_;
 
-    mutable std::unordered_map<cell_member_type, std::string> probe_files_;
     cell_size_type num_cells_;
 };

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -2,9 +2,11 @@
 set(unit_sources
     test_csv.cpp
     test_hdf5.cpp
-    test_databse.cpp
+    test_model_desc.cpp
+    test_io_desc.cpp
 
-    # unit test driver
+
+        # unit test driver
     test.cpp
 )
 

--- a/test/unit/test_io_desc.cpp
+++ b/test/unit/test_io_desc.cpp
@@ -1,0 +1,80 @@
+#include <arbor/cable_cell.hpp>
+
+#include "hdf5_lib.hpp"
+#include "csv_lib.hpp"
+#include "data_management_lib.hpp"
+#include "sonata_exceptions.hpp"
+
+#include "../gtest.h"
+
+io_desc simple_input() {
+    std::string datadir{DATADIR};
+
+    auto nodes0 = datadir + "/nodes_0.h5";
+    auto nodes1 = datadir + "/nodes_1.h5";
+    auto nodes2 = datadir + "/nodes_2.h5";
+
+    auto n0 = std::make_shared<h5_file>(nodes0);
+    auto n1 = std::make_shared<h5_file>(nodes1);
+    auto n2 = std::make_shared<h5_file>(nodes2);
+
+    h5_record nodes({n0, n1, n2});
+
+    auto spikes0 = datadir + "/spikes_0.h5";
+    auto spikes1 = datadir + "/spikes_1.h5";
+
+    h5_wrapper spike_gp0(h5_file(spikes0).top_group_);
+    h5_wrapper spike_gp1(h5_file(spikes1).top_group_);
+
+    std::vector<spike_in_info> spike_vec = {{spike_gp0, "pop_e"}, {spike_gp1, "pop_i"}};
+
+    auto clamp_input = datadir + "/clamp_input.csv";
+    auto clamp_electrode = datadir + "/clamp_electrode.csv";
+
+    csv_file clamp_in(clamp_input);
+    csv_file clamp_elec(clamp_electrode);
+
+    std::vector<current_clamp_info> clamp_vec = {{clamp_elec, clamp_in}};
+
+    io_desc in(nodes, spike_vec, clamp_vec, {});
+
+    return std::move(in);
+}
+
+TEST(io_desc, spikes) {
+    auto in = simple_input();
+
+    for (unsigned i = 0; i < 4; i++) {
+        auto spikes = in.get_spikes(i);
+
+        std::vector<double> expected;
+        for (auto j = 0; j < 5; j++) {
+            expected.push_back(j*15 + i*15);
+        }
+
+        EXPECT_EQ(expected, spikes);
+    }
+    {
+        auto spikes = in.get_spikes(4);
+        std::vector<double> expected;
+        expected.push_back(37);
+        expected.push_back(54);
+
+        EXPECT_EQ(expected, spikes);
+    }
+    {
+        auto spikes = in.get_spikes(5);
+        EXPECT_TRUE(spikes.empty());
+    }
+}
+
+TEST(io_desc, clamps) {
+    auto in = simple_input();
+
+    auto clamps = in.get_current_clamps(0);
+    EXPECT_EQ(1, clamps.size());
+    EXPECT_EQ(arb::segment_location({0,0.5}), clamps.front().stim_loc);
+    EXPECT_EQ(0, clamps.front().delay);
+    EXPECT_EQ(0.4, clamps.front().amplitude);
+    EXPECT_EQ(5, clamps.front().duration);
+}

--- a/test/unit/test_model_desc.cpp
+++ b/test/unit/test_model_desc.cpp
@@ -18,16 +18,12 @@
 //          |      |       |
 //  pop_i:  |____> n4 <____|
 
-database simple_network() {
+model_desc simple_network() {
     std::string datadir{DATADIR};
 
     auto nodes0 = datadir + "/nodes_0.h5";
     auto nodes1 = datadir + "/nodes_1.h5";
     auto nodes2 = datadir + "/nodes_2.h5";
-    auto spikes0 = datadir + "/spikes_0.h5";
-    auto spikes1 = datadir + "/spikes_1.h5";
-    auto clamp_input = datadir + "/clamp_input.csv";
-    auto clamp_electrode = datadir + "/clamp_electrode.csv";
 
     auto n0 = std::make_shared<h5_file>(nodes0);
     auto n1 = std::make_shared<h5_file>(nodes1);
@@ -56,55 +52,44 @@ database simple_network() {
     auto nf = csv_file(nodes3);
     auto n_base = csv_node_record({nf});
 
-    h5_wrapper spike_gp0(h5_file(spikes0).top_group_);
-    h5_wrapper spike_gp1(h5_file(spikes1).top_group_);
+    model_desc md(nodes, edges, n_base, e_base);
 
-    std::vector<spike_info> spike_vec = {{spike_gp0, "pop_e"}, {spike_gp1, "pop_i"}};
-
-    csv_file clamp_in(clamp_input);
-    csv_file clamp_elec(clamp_electrode);
-
-    std::vector<current_clamp_info> clamp_vec = {{clamp_elec, clamp_in}};
-
-    database db(nodes, edges, n_base, e_base, spike_vec, clamp_vec);
-
-    return std::move(db);
+    return std::move(md);
 }
 
+TEST(model_desc, helper_functions) {
 
-TEST(database, helper_functions) {
+    auto md = simple_network();
 
-    auto db = simple_network();
+    EXPECT_EQ(6, md.num_cells());
 
-    EXPECT_EQ(6, db.num_cells());
+    EXPECT_EQ(std::vector<unsigned>({0,4,5,6}), md.pop_partitions());
+    EXPECT_EQ(std::vector<std::string>({"pop_e", "pop_i" ,"pop_ext"}), md.pop_names());
 
-    EXPECT_EQ(std::vector<unsigned>({0,4,5,6}), db.pop_partitions());
-    EXPECT_EQ(std::vector<std::string>({"pop_e", "pop_i" ,"pop_ext"}), db.pop_names());
+    EXPECT_EQ("pop_e", md.population_of(0));
+    EXPECT_EQ("pop_e", md.population_of(1));
+    EXPECT_EQ("pop_e", md.population_of(2));
+    EXPECT_EQ("pop_e", md.population_of(3));
+    EXPECT_EQ("pop_i", md.population_of(4));
+    EXPECT_EQ("pop_ext", md.population_of(5));
 
-    EXPECT_EQ("pop_e", db.population_of(0));
-    EXPECT_EQ("pop_e", db.population_of(1));
-    EXPECT_EQ("pop_e", db.population_of(2));
-    EXPECT_EQ("pop_e", db.population_of(3));
-    EXPECT_EQ("pop_i", db.population_of(4));
-    EXPECT_EQ("pop_ext", db.population_of(5));
-
-    EXPECT_EQ(0, db.population_id_of(0));
-    EXPECT_EQ(1, db.population_id_of(1));
-    EXPECT_EQ(2, db.population_id_of(2));
-    EXPECT_EQ(3, db.population_id_of(3));
-    EXPECT_EQ(0, db.population_id_of(4));
-    EXPECT_EQ(0, db.population_id_of(5));
+    EXPECT_EQ(0, md.population_id_of(0));
+    EXPECT_EQ(1, md.population_id_of(1));
+    EXPECT_EQ(2, md.population_id_of(2));
+    EXPECT_EQ(3, md.population_id_of(3));
+    EXPECT_EQ(0, md.population_id_of(4));
+    EXPECT_EQ(0, md.population_id_of(5));
 }
 
-TEST(database, source_target_maps) {
-    auto db = simple_network();
+TEST(model_desc, source_target_maps) {
+    auto md = simple_network();
 
-    auto verify_src_tgt = [&db](const std::vector<arb::group_description>& decomp) {
-        db.build_source_and_target_maps(decomp);
+    auto verify_src_tgt = [&md](const std::vector<arb::group_description>& decomp) {
+        md.build_source_and_target_maps(decomp);
 
         std::vector<segment_location> srcs;
         std::vector<std::pair<segment_location, arb::mechanism_desc>> tgts;
-        db.get_sources_and_targets(0, srcs, tgts);
+        md.get_sources_and_targets(0, srcs, tgts);
 
         EXPECT_EQ(1, srcs.size());
         EXPECT_EQ(1, srcs[0].segment);
@@ -117,7 +102,7 @@ TEST(database, source_target_maps) {
 
         srcs.clear();
         tgts.clear();
-        db.get_sources_and_targets(1, srcs, tgts);
+        md.get_sources_and_targets(1, srcs, tgts);
 
         EXPECT_EQ(1, srcs.size());
         EXPECT_EQ(1, srcs[0].segment);
@@ -132,7 +117,7 @@ TEST(database, source_target_maps) {
 
         srcs.clear();
         tgts.clear();
-        db.get_sources_and_targets(2, srcs, tgts);
+        md.get_sources_and_targets(2, srcs, tgts);
 
         EXPECT_EQ(1, srcs.size());
         EXPECT_EQ(3, srcs[0].segment);
@@ -145,7 +130,7 @@ TEST(database, source_target_maps) {
 
         srcs.clear();
         tgts.clear();
-        db.get_sources_and_targets(3, srcs, tgts);
+        md.get_sources_and_targets(3, srcs, tgts);
 
         EXPECT_EQ(0, srcs.size());
 
@@ -156,7 +141,7 @@ TEST(database, source_target_maps) {
 
         srcs.clear();
         tgts.clear();
-        db.get_sources_and_targets(4, srcs, tgts);
+        md.get_sources_and_targets(4, srcs, tgts);
 
         EXPECT_EQ(1, srcs.size());
         EXPECT_EQ(0, srcs[0].segment);
@@ -175,14 +160,14 @@ TEST(database, source_target_maps) {
     verify_src_tgt({decomp});
 }
 
-TEST(database, connections) {
-    auto db = simple_network();
+TEST(model_desc, connections) {
+    auto md = simple_network();
 
     auto decomp = arb::group_description(arb::cell_kind::cable, {0,1,2,3,4,5}, arb::backend_kind::multicore);
-    db.build_source_and_target_maps({decomp});
+    md.build_source_and_target_maps({decomp});
 
     std::vector<arb::cell_connection> conns;
-    db.get_connections(0, conns);
+    md.get_connections(0, conns);
     EXPECT_EQ(1, conns.size());
     EXPECT_EQ(5,conns[0].source.gid);
     EXPECT_EQ(0,conns[0].source.index);
@@ -192,7 +177,7 @@ TEST(database, connections) {
     EXPECT_NEAR(0.1,conns[0].delay,1e-5);
 
     conns.clear();
-    db.get_connections(1, conns);
+    md.get_connections(1, conns);
     EXPECT_EQ(1, conns.size());
     EXPECT_EQ(4,conns[0].source.gid);
     EXPECT_EQ(0,conns[0].source.index);
@@ -202,7 +187,7 @@ TEST(database, connections) {
     EXPECT_NEAR(0.1,conns[0].delay,1e-5);
 
     conns.clear();
-    db.get_connections(2, conns);
+    md.get_connections(2, conns);
     EXPECT_EQ(1, conns.size());
     EXPECT_EQ(5,conns[0].source.gid);
     EXPECT_EQ(0,conns[0].source.index);
@@ -212,7 +197,7 @@ TEST(database, connections) {
     EXPECT_NEAR(0.1,conns[0].delay,1e-5);
 
     conns.clear();
-    db.get_connections(3, conns);
+    md.get_connections(3, conns);
     EXPECT_EQ(1, conns.size());
     EXPECT_EQ(1,conns[0].source.gid);
     EXPECT_EQ(0,conns[0].source.index);
@@ -222,7 +207,7 @@ TEST(database, connections) {
     EXPECT_NEAR(0.2,conns[0].delay,1e-5);
 
     conns.clear();
-    db.get_connections(4, conns);
+    md.get_connections(4, conns);
     EXPECT_EQ(2, conns.size());
     EXPECT_EQ(0,conns[0].source.gid);
     EXPECT_EQ(0,conns[0].source.index);
@@ -240,40 +225,40 @@ TEST(database, connections) {
 
 }
 
-TEST(database, morphologies) {
-    auto db = simple_network();
+TEST(model_desc, morphologies) {
+    auto md = simple_network();
 
     for (auto i = 0; i < 4; i++) {
-        auto morph = db.get_cell_morphology(i);
+        auto morph = md.get_cell_morphology(i);
         EXPECT_TRUE(morph.has_soma());
         EXPECT_DOUBLE_EQ(6.30785, morph.soma.r);
         EXPECT_EQ(1, morph.sections.size());
     }
 
-    auto morph = db.get_cell_morphology(4);
+    auto morph = md.get_cell_morphology(4);
     EXPECT_TRUE(morph.has_soma());
     EXPECT_DOUBLE_EQ(3.5, morph.soma.r);
     EXPECT_EQ(0, morph.sections.size());
 
-    EXPECT_THROW(db.get_cell_morphology(5), sonata_exception);
+    EXPECT_THROW(md.get_cell_morphology(5), sonata_exception);
 }
 
-TEST(database, cell_kinds) {
-    auto db = simple_network();
+TEST(model_desc, cell_kinds) {
+    auto md = simple_network();
 
     for (unsigned i = 0; i < 5; i++) {
-        auto kind = db.get_cell_kind(i);
+        auto kind = md.get_cell_kind(i);
         EXPECT_EQ(arb::cell_kind::cable, kind);
     }
-    auto kind = db.get_cell_kind(5);
+    auto kind = md.get_cell_kind(5);
     EXPECT_EQ(arb::cell_kind::spike_source, kind);
 }
 
-TEST(database, density_mechs) {
-    auto db = simple_network();
+TEST(model_desc, density_mechs) {
+    auto md = simple_network();
 
     for (unsigned i = 0; i < 5; i++) {
-        auto mechs_per_sec = db.get_density_mechs(i);
+        auto mechs_per_sec = md.get_density_mechs(i);
         EXPECT_EQ(2, mechs_per_sec.size());
         EXPECT_TRUE(mechs_per_sec.find("soma") != mechs_per_sec.end());
         EXPECT_TRUE(mechs_per_sec.find("dend") != mechs_per_sec.end());
@@ -308,44 +293,6 @@ TEST(database, density_mechs) {
         }
     }
 
-    auto mechs_per_sec = db.get_density_mechs(5);
+    auto mechs_per_sec = md.get_density_mechs(5);
     EXPECT_EQ(0, mechs_per_sec.size());
-}
-
-TEST(database, spikes) {
-    auto db = simple_network();
-
-    for (unsigned i = 0; i < 4; i++) {
-        auto spikes = db.get_spikes(i);
-
-        std::vector<double> expected;
-        for (auto j = 0; j < 5; j++) {
-            expected.push_back(j*15 + i*15);
-        }
-
-        EXPECT_EQ(expected, spikes);
-    }
-    {
-        auto spikes = db.get_spikes(4);
-        std::vector<double> expected;
-        expected.push_back(37);
-        expected.push_back(54);
-
-        EXPECT_EQ(expected, spikes);
-    }
-    {
-        auto spikes = db.get_spikes(5);
-        EXPECT_TRUE(spikes.empty());
-    }
-}
-
-TEST(database, clamps) {
-    auto db = simple_network();
-
-    auto clamps = db.get_current_clamps(0);
-    EXPECT_EQ(1, clamps.size());
-    EXPECT_EQ(arb::segment_location({0,0.5}), clamps.front().stim_loc);
-    EXPECT_EQ(0, clamps.front().delay);
-    EXPECT_EQ(0.4, clamps.front().amplitude);
-    EXPECT_EQ(5, clamps.front().duration);
 }


### PR DESCRIPTION
Refactor `database` into `model_desc` and `io_desc` - cass was getting too big.
Move probe querying from `sonata_rcipe`  into `io_desc`
Fix unit tests