### PR TITLE
Add writing ability to hdf5_lib and clean up reading

### DIFF
--- a/sonata/data_management_lib.cpp
+++ b/sonata/data_management_lib.cpp
@@ -74,10 +74,10 @@ void model_desc::build_source_and_target_maps(const std::vector<arb::group_descr
                     auto edge_pop = edges_.map()[edge_pop_name];
                     auto ind_id = edges_[edge_pop].find_group("indicies");
                     auto s2t_id = edges_[edge_pop][ind_id].find_group("source_to_target");
-                    auto n2r_range = edges_[edge_pop][ind_id][s2t_id].int_pair_at("node_id_to_ranges", loc_node.el_id);
+                    auto n2r_range = edges_[edge_pop][ind_id][s2t_id].get<std::pair<int,int>>("node_id_to_ranges", loc_node.el_id);
 
                     for (auto j = n2r_range.first; j < n2r_range.second; j++) {
-                        auto r2e = edges_[edge_pop][ind_id][s2t_id].int_pair_at("range_to_edge_id", j);
+                        auto r2e = edges_[edge_pop][ind_id][s2t_id].get<std::pair<int,int>>("range_to_edge_id", j);
                         auto src_rng = source_range(edge_pop, r2e);
                         for (auto s: src_rng) {
                             auto loc = src_set.find(s);
@@ -95,9 +95,9 @@ void model_desc::build_source_and_target_maps(const std::vector<arb::group_descr
 
                     auto ind_id = edges_[edge_pop].find_group("indicies");
                     auto t2s_id = edges_[edge_pop][ind_id].find_group("target_to_source");
-                    auto n2r = edges_[edge_pop][ind_id][t2s_id].int_pair_at("node_id_to_ranges", loc_node.el_id);
+                    auto n2r = edges_[edge_pop][ind_id][t2s_id].get<std::pair<int,int>>("node_id_to_ranges", loc_node.el_id);
                     for (auto j = n2r.first; j < n2r.second; j++) {
-                        auto r2e = edges_[edge_pop][ind_id][t2s_id].int_pair_at("range_to_edge_id", j);
+                        auto r2e = edges_[edge_pop][ind_id][t2s_id].get<std::pair<int,int>>("range_to_edge_id", j);
 
                         auto tgt_rng = target_range(edge_pop, r2e);
 
@@ -176,16 +176,16 @@ arb::morphology model_desc::get_cell_morphology(cell_gid_type gid) {
     auto node_pop_id = nodes_.map()[node_pop_name];
     auto node_id = loc_node.el_id;
 
-    auto group_id = nodes_[node_pop_id].int_at("node_group_id", node_id);
-    auto group_idx = nodes_[node_pop_id].int_at("node_group_index", node_id);
+    auto group_id = nodes_[node_pop_id].get<int>("node_group_id", node_id);
+    auto group_idx = nodes_[node_pop_id].get<int>("node_group_index", node_id);
 
-    auto node_type_tag = nodes_[node_pop_id].int_at("node_type_id", node_id);
+    auto node_type_tag = nodes_[node_pop_id].get<int>("node_type_id", node_id);
 
     if (nodes_[node_pop_id].find_group(std::to_string(group_id)) != -1) {
         auto lgi = nodes_[node_pop_id].find_group(std::to_string(group_id));
         auto group = nodes_[node_pop_id][lgi];
         if (group.find_dataset("morphology") != -1) {
-            auto file = group.string_at("morphology", group_idx);
+            auto file = group.get<std::string>("morphology", group_idx);
 
             std::ifstream f(file);
             if (!f) throw sonata_exception("Unable to open SWC file");
@@ -202,7 +202,7 @@ arb::cell_kind model_desc::get_cell_kind(cell_gid_type gid) {
     auto node_pop_id = nodes_.map()[node_pop_name];
     auto node_id = loc_node.el_id;
 
-    auto node_type_tag = nodes_[node_pop_id].int_at("node_type_id", node_id);
+    auto node_type_tag = nodes_[node_pop_id].get<int>("node_type_id", node_id);
 
     return node_types_.cell_kind(type_pop_id(node_type_tag, node_pop_name));
 }
@@ -224,16 +224,16 @@ void model_desc::get_connections(cell_gid_type gid, std::vector<arb::cell_connec
 
             auto ind_id = edges_[edge_pop].find_group("indicies");
             auto s2t_id = edges_[edge_pop][ind_id].find_group("target_to_source");
-            auto n2r_range = edges_[edge_pop][ind_id][s2t_id].int_pair_at("node_id_to_ranges", loc_node.el_id);
+            auto n2r_range = edges_[edge_pop][ind_id][s2t_id].get<std::pair<int,int>>("node_id_to_ranges", loc_node.el_id);
 
             for (auto j = n2r_range.first; j < n2r_range.second; j++) {
-                auto r2e = edges_[edge_pop][ind_id][s2t_id].int_pair_at("range_to_edge_id", j);
+                auto r2e = edges_[edge_pop][ind_id][s2t_id].get<std::pair<int,int>>("range_to_edge_id", j);
                 auto src_rng = source_range(edge_pop, r2e);
                 auto tgt_rng = target_range(edge_pop, r2e);
                 auto weights = weight_range(edge_pop, r2e);
                 auto delays = delay_range(edge_pop, r2e);
 
-                auto src_id = edges_[edge_pop].int_range("source_node_id", r2e.first, r2e.second);
+                auto src_id = edges_[edge_pop].get<std::vector<int>>("source_node_id", r2e.first, r2e.second);
 
                 std::vector<cell_member_type> sources, targets;
 
@@ -294,10 +294,10 @@ std::unordered_map<arb::section_kind, std::vector<arb::mechanism_desc>> model_de
     auto node_pop_id = nodes_.map()[node_pop_name];
     auto node_id = loc_node.el_id;
 
-    auto nodes_grp_id = nodes_[node_pop_id].int_at("node_group_id", node_id);
-    auto nodes_grp_idx = nodes_[node_pop_id].int_at("node_group_index", node_id);
+    auto nodes_grp_id = nodes_[node_pop_id].get<int>("node_group_id", node_id);
+    auto nodes_grp_idx = nodes_[node_pop_id].get<int>("node_group_index", node_id);
 
-    auto nodes_type_tag = nodes_[node_pop_id].int_at("node_type_id", node_id);
+    auto nodes_type_tag = nodes_[node_pop_id].get<int>("node_type_id", node_id);
     auto nodes_pop_name = nodes_[node_pop_id].name();
 
     auto node_unique_id = type_pop_id(nodes_type_tag, nodes_pop_name);
@@ -317,7 +317,7 @@ std::unordered_map<arb::section_kind, std::vector<arb::mechanism_desc>> model_de
                     auto dpi = group.find_group("dynamics_params");
                     auto dyn_params = group[dpi];
                     if (dyn_params.find_dataset(gp_var_id) != -1) {
-                        auto value = dyn_params.double_at(gp_var_id, nodes_grp_idx);
+                        auto value = dyn_params.get<double>(gp_var_id, nodes_grp_idx);
                         density_vars[gp_id][var_id] = value;
                     }
                 }
@@ -335,10 +335,10 @@ std::unordered_map<arb::section_kind, std::vector<arb::mechanism_desc>> model_de
 std::vector<source_type> model_desc::source_range(unsigned edge_pop_id, std::pair<unsigned, unsigned> edge_range) {
     std::vector<source_type> ret;
 
-    // First read edge_group_id and edge_group_index and edge_type
-    auto edges_grp_id = edges_[edge_pop_id].int_range("edge_group_id", edge_range.first, edge_range.second);
-    auto edges_grp_idx = edges_[edge_pop_id].int_range("edge_group_index", edge_range.first, edge_range.second);
-    auto edges_type_tag = edges_[edge_pop_id].int_range("edge_type_id", edge_range.first, edge_range.second);
+    // First get edge_group_id and edge_group_index and edge_type
+    auto edges_grp_id = edges_[edge_pop_id].get<std::vector<int>>("edge_group_id", edge_range.first, edge_range.second);
+    auto edges_grp_idx = edges_[edge_pop_id].get<std::vector<int>>("edge_group_index", edge_range.first, edge_range.second);
+    auto edges_type_tag = edges_[edge_pop_id].get<std::vector<int>>("edge_type_id", edge_range.first, edge_range.second);
     auto edges_pop_name = edges_[edge_pop_id].name();
 
     for (unsigned i = 0; i < edges_grp_id.size(); i++) {
@@ -357,11 +357,11 @@ std::vector<source_type> model_desc::source_range(unsigned edge_pop_id, std::pai
             auto loc_grp_idx = edges_grp_idx[i];
 
             if (group.find_dataset("efferent_section_id") != -1) {
-                source_branch = group.int_at("efferent_section_id", loc_grp_idx);
+                source_branch = group.get<int>("efferent_section_id", loc_grp_idx);
                 found_source_branch = true;
             }
             if (group.find_dataset("efferent_section_pos") != -1) {
-                source_pos = group.double_at("efferent_section_pos", loc_grp_idx);
+                source_pos = group.get<double>("efferent_section_pos", loc_grp_idx);
                 found_source_pos = true;
             }
         }
@@ -385,9 +385,9 @@ std::vector<target_type> model_desc::target_range(unsigned edge_pop_id, std::pai
     std::vector<target_type> ret;
 
     // First read edge_group_id and edge_group_index and edge_type
-    auto edges_grp_id = edges_[edge_pop_id].int_range("edge_group_id", edge_range.first, edge_range.second);
-    auto edges_grp_idx = edges_[edge_pop_id].int_range("edge_group_index", edge_range.first, edge_range.second);
-    auto edges_type_tag = edges_[edge_pop_id].int_range("edge_type_id", edge_range.first, edge_range.second);
+    auto edges_grp_id = edges_[edge_pop_id].get<std::vector<int>>("edge_group_id", edge_range.first, edge_range.second);
+    auto edges_grp_idx = edges_[edge_pop_id].get<std::vector<int>>("edge_group_index", edge_range.first, edge_range.second);
+    auto edges_type_tag = edges_[edge_pop_id].get<std::vector<int>>("edge_type_id", edge_range.first, edge_range.second);
     auto edges_pop_name = edges_[edge_pop_id].name();
 
     auto cat = arb::global_default_catalogue();
@@ -410,15 +410,15 @@ std::vector<target_type> model_desc::target_range(unsigned edge_pop_id, std::pai
             auto loc_grp_idx = edges_grp_idx[i];
 
             if (group.find_dataset("afferent_section_id") != -1) {
-                target_branch = group.int_at("afferent_section_id", loc_grp_idx);
+                target_branch = group.get<int>("afferent_section_id", loc_grp_idx);
                 found_target_branch = true;
             }
             if (group.find_dataset("afferent_section_pos") != -1) {
-                target_pos = group.double_at("afferent_section_pos", loc_grp_idx);
+                target_pos = group.get<double>("afferent_section_pos", loc_grp_idx);
                 found_target_pos = true;
             }
             if (group.find_dataset("model_template") != -1) {
-                synapse = group.string_at("model_template", loc_grp_idx);
+                synapse = group.get<std::string>("model_template", loc_grp_idx);
                 found_synapse = true;
             }
         }
@@ -470,7 +470,7 @@ std::vector<target_type> model_desc::target_range(unsigned edge_pop_id, std::pai
                 if (dpi != -1) {
                     auto dyn_params = group[dpi];
                     if (dyn_params.find_dataset(p.first) != -1) {
-                        syn_params[p.first] = dyn_params.double_at(p.first, loc_grp_idx);
+                        syn_params[p.first] = dyn_params.get<double>(p.first, loc_grp_idx);
                     }
                 }
             }
@@ -489,9 +489,9 @@ std::vector<double> model_desc::weight_range(unsigned edge_pop_id, std::pair<uns
     std::vector<double> ret;
 
     // First read edge_group_id and edge_group_index and edge_type
-    auto edges_grp_id = edges_[edge_pop_id].int_range("edge_group_id", edge_range.first, edge_range.second);
-    auto edges_grp_idx = edges_[edge_pop_id].int_range("edge_group_index", edge_range.first, edge_range.second);
-    auto edges_type_tag = edges_[edge_pop_id].int_range("edge_type_id", edge_range.first, edge_range.second);
+    auto edges_grp_id = edges_[edge_pop_id].get<std::vector<int>>("edge_group_id", edge_range.first, edge_range.second);
+    auto edges_grp_idx = edges_[edge_pop_id].get<std::vector<int>>("edge_group_index", edge_range.first, edge_range.second);
+    auto edges_type_tag = edges_[edge_pop_id].get<std::vector<int>>("edge_type_id", edge_range.first, edge_range.second);
     auto edges_pop_name = edges_[edge_pop_id].name();
 
     for (unsigned i = 0; i < edges_grp_id.size(); i++) {
@@ -507,7 +507,7 @@ std::vector<double> model_desc::weight_range(unsigned edge_pop_id, std::pair<uns
             auto loc_grp_idx = edges_grp_idx[i];
 
             if (group.find_dataset("syn_weight") != -1) {
-                weight = group.double_at("syn_weight", loc_grp_idx);
+                weight = group.get<double>("syn_weight", loc_grp_idx);
                 found_weight = true;
             }
         }
@@ -531,9 +531,9 @@ std::vector<double> model_desc::delay_range(unsigned edge_pop_id, std::pair<unsi
     std::vector<double> ret;
 
     // First read edge_group_id and edge_group_index and edge_type
-    auto edges_grp_id = edges_[edge_pop_id].int_range("edge_group_id", edge_range.first, edge_range.second);
-    auto edges_grp_idx = edges_[edge_pop_id].int_range("edge_group_index", edge_range.first, edge_range.second);
-    auto edges_type_tag = edges_[edge_pop_id].int_range("edge_type_id", edge_range.first, edge_range.second);
+    auto edges_grp_id = edges_[edge_pop_id].get<std::vector<int>>("edge_group_id", edge_range.first, edge_range.second);
+    auto edges_grp_idx = edges_[edge_pop_id].get<std::vector<int>>("edge_group_index", edge_range.first, edge_range.second);
+    auto edges_type_tag = edges_[edge_pop_id].get<std::vector<int>>("edge_type_id", edge_range.first, edge_range.second);
     auto edges_pop_name = edges_[edge_pop_id].name();
 
     for (unsigned i = 0; i < edges_grp_id.size(); i++) {
@@ -549,7 +549,7 @@ std::vector<double> model_desc::delay_range(unsigned edge_pop_id, std::pair<unsi
             auto loc_grp_idx = edges_grp_idx[i];
 
             if (group.find_dataset("delay") != -1) {
-                delay = group.double_at("delay", loc_grp_idx);
+                delay = group.get<double>("delay", loc_grp_idx);
                 found_delay = true;
             }
         }
@@ -595,9 +595,9 @@ void io_desc::build_spike_map(std::vector<spike_in_info> spikes) {
             if (spike_idx == -1) {
                 throw sonata_exception("Input spikes file doesn't have top level group \"spikes\"");
             }
-            auto range = sp.data[spike_idx].int_pair_at("gid_to_range", loc_cell.el_id);
+            auto range = sp.data[spike_idx].get<std::pair<int,int>>("gid_to_range", loc_cell.el_id);
 
-            auto spk_times = sp.data[spike_idx].double_range("timestamps", range.first, range.second);
+            auto spk_times = sp.data[spike_idx].get<std::vector<double>>("timestamps", range.first, range.second);
 
             spike_times.insert(spike_times.end(), spk_times.begin(), spk_times.end());
         }

--- a/sonata/hdf5_lib.cpp
+++ b/sonata/hdf5_lib.cpp
@@ -378,24 +378,8 @@ std::shared_ptr<h5_group> h5_group::add_group(std::string name) {
     return new_group;
 }
 
-void h5_group::add_dataset(std::string name, std::vector<int> dset) {
-    auto new_dataset = std::make_shared<h5_dataset>(group_h_.id, name, dset);
-    datasets_.emplace_back(new_dataset);
-}
-
-
-void h5_group::add_dataset(std::string name, std::vector<double> dset) {
-    auto new_dataset = std::make_shared<h5_dataset>(group_h_.id, name, dset);
-    datasets_.emplace_back(new_dataset);
-}
-
-void h5_group::add_dataset(std::string name, std::vector<std::vector<int>> dset) {
-    auto new_dataset = std::make_shared<h5_dataset>(group_h_.id, name, dset);
-    datasets_.emplace_back(new_dataset);
-}
-
-
-void h5_group::add_dataset(std::string name, std::vector<std::vector<double>> dset) {
+template <typename T>
+void h5_group::add_dataset(std::string name, std::vector<T> dset) {
     auto new_dataset = std::make_shared<h5_dataset>(group_h_.id, name, dset);
     datasets_.emplace_back(new_dataset);
 }
@@ -676,3 +660,8 @@ std::unordered_map<std::string, unsigned> h5_record::map() const {
 std::vector<std::string> h5_record::pop_names() const {
     return pop_names_;
 }
+
+template void h5_group::add_dataset<int>(std::string, std::vector<int>);
+template void h5_group::add_dataset<double>(std::string, std::vector<double>);
+template void h5_group::add_dataset<std::vector<int>>(std::string, std::vector<std::vector<int>>);
+template void h5_group::add_dataset<std::vector<double>>(std::string, std::vector<std::vector<double>>);

--- a/sonata/hdf5_lib.cpp
+++ b/sonata/hdf5_lib.cpp
@@ -14,8 +14,8 @@
 ///h5_dataset methods
 
 h5_dataset::h5_dataset(hid_t parent, std::string name): parent_id_(parent), name_(name) {
-    auto id_ = H5Dopen(parent_id_, name_.c_str(), H5P_DEFAULT);
-    hid_t dspace = H5Dget_space(id_);
+    auto id = H5Dopen(parent_id_, name_.c_str(), H5P_DEFAULT);
+    hid_t dspace = H5Dget_space(id);
 
     const int ndims = H5Sget_simple_extent_ndims(dspace);
 
@@ -25,63 +25,63 @@ h5_dataset::h5_dataset(hid_t parent, std::string name): parent_id_(parent), name
     size_ = dims[0];
 
     H5Sclose(dspace);
-    H5Dclose(id_);
+    H5Dclose(id);
 }
 
 h5_dataset::h5_dataset(hid_t parent, std::string name, std::vector<int> data): parent_id_(parent), name_(name) {
     hsize_t size = data.size();
     auto dspace = H5Screate_simple(1, &size, NULL);
 
-    auto id_ = H5Dcreate(parent_id_, name.c_str(), H5T_NATIVE_INT, dspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    auto id = H5Dcreate(parent_id_, name.c_str(), H5T_NATIVE_INT, dspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     int arr[size];
     std::copy(data.begin(), data.end(), arr);
-    H5Dwrite(id_, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, arr);
+    H5Dwrite(id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, arr);
 
     H5Sclose(dspace);
-    H5Dclose(id_);
+    H5Dclose(id);
 }
 
 h5_dataset::h5_dataset(hid_t parent, std::string name, std::vector<double> data): parent_id_(parent), name_(name) {
     hsize_t size = data.size();
     auto dspace = H5Screate_simple(1, &size, NULL);
 
-    auto id_ = H5Dcreate(parent_id_, name.c_str(), H5T_NATIVE_DOUBLE, dspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    auto id = H5Dcreate(parent_id_, name.c_str(), H5T_NATIVE_DOUBLE, dspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     double arr[size];
     std::copy(data.begin(), data.end(), arr);
-    H5Dwrite(id_, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, arr);
+    H5Dwrite(id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, arr);
 
     H5Sclose(dspace);
-    H5Dclose(id_);
+    H5Dclose(id);
 }
 
 h5_dataset::h5_dataset(hid_t parent, std::string name, std::vector<std::vector<int>> data): parent_id_(parent), name_(name) {
     hsize_t dims_data[2] = {data.size(), data.front().size()};
     auto dspace = H5Screate_simple(2, dims_data, NULL);
 
-    auto id_ = H5Dcreate(parent_id_, name.c_str(), H5T_NATIVE_INT, dspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    auto id = H5Dcreate(parent_id_, name.c_str(), H5T_NATIVE_INT, dspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     int arr[data.size()][data.front().size()];
     for (unsigned i = 0; i < data.size(); i++) {
         std::copy(data[i].begin(), data[i].end(), arr[i]);
     }
-    H5Dwrite(id_, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, arr);
+    H5Dwrite(id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, arr);
 
     H5Sclose(dspace);
-    H5Dclose(id_);
+    H5Dclose(id);
 }
 
 h5_dataset::h5_dataset(hid_t parent, std::string name, std::vector<std::vector<double>> data): parent_id_(parent), name_(name) {
     hsize_t dims_data[2] = {data.size(), data.front().size()};
     auto dspace = H5Screate_simple(2, dims_data, NULL);
 
-    auto id_ = H5Dcreate(parent_id_, name.c_str(), H5T_NATIVE_DOUBLE, dspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    auto id = H5Dcreate(parent_id_, name.c_str(), H5T_NATIVE_DOUBLE, dspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     double arr[data.size()][data.front().size()];
     for (unsigned i = 0; i < data.size(); i++) {
         std::copy(data[i].begin(), data[i].end(), arr[i]);
     }
-    H5Dwrite(id_, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, arr);
+    H5Dwrite(id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, arr);
 
     H5Sclose(dspace);
-    H5Dclose(id_);
+    H5Dclose(id);
 }
 
 std::string h5_dataset::name() {
@@ -105,18 +105,18 @@ auto h5_dataset::int_at(const int i) {
     // Output size
     hsize_t num_elements = 1;
 
-    auto id_ = H5Dopen(parent_id_, name_.c_str(), H5P_DEFAULT);
-    hid_t dspace = H5Dget_space(id_);
+    auto id = H5Dopen(parent_id_, name_.c_str(), H5P_DEFAULT);
+    hid_t dspace = H5Dget_space(id);
 
     H5Sselect_elements(dspace, H5S_SELECT_SET, num_elements, &idx);
 
     hid_t out_mem = H5Screate_simple(dims, dim_sizes, NULL);
 
-    auto status = H5Dread(id_, H5T_NATIVE_INT, out_mem, dspace, H5P_DEFAULT, out);
+    auto status = H5Dread(id, H5T_NATIVE_INT, out_mem, dspace, H5P_DEFAULT, out);
 
     H5Sclose(dspace);
     H5Sclose(out_mem);
-    H5Dclose(id_);
+    H5Dclose(id);
 
     if (status < 0 ) {
         throw sonata_dataset_exception(name_, (unsigned)i);
@@ -141,17 +141,17 @@ auto h5_dataset::double_at(const int i) {
     // Output size
     hsize_t num_elements = 1;
 
-    auto id_ = H5Dopen(parent_id_, name_.c_str(), H5P_DEFAULT);
-    hid_t dspace = H5Dget_space(id_);
+    auto id = H5Dopen(parent_id_, name_.c_str(), H5P_DEFAULT);
+    hid_t dspace = H5Dget_space(id);
 
     H5Sselect_elements(dspace, H5S_SELECT_SET, num_elements, &idx);
     hid_t out_mem = H5Screate_simple(dims, dim_sizes, NULL);
 
-    auto status = H5Dread(id_, H5T_NATIVE_DOUBLE, out_mem, dspace, H5P_DEFAULT, out);
+    auto status = H5Dread(id, H5T_NATIVE_DOUBLE, out_mem, dspace, H5P_DEFAULT, out);
 
     H5Sclose(dspace);
     H5Sclose(out_mem);
-    H5Dclose(id_);
+    H5Dclose(id);
 
     if (status < 0) {
         throw sonata_dataset_exception(name_, (unsigned)i);
@@ -220,17 +220,17 @@ auto h5_dataset::int_range(const int i, const int j) {
 
     int rdata[count];
 
-    auto id_ = H5Dopen(parent_id_, name_.c_str(), H5P_DEFAULT);
-    hid_t dspace = H5Dget_space(id_);
+    auto id = H5Dopen(parent_id_, name_.c_str(), H5P_DEFAULT);
+    hid_t dspace = H5Dget_space(id);
 
     hid_t out_mem = H5Screate_simple(1, &dimsm, NULL);
 
     H5Sselect_hyperslab(dspace, H5S_SELECT_SET, &offset, &stride, &count, &block);
-    auto status = H5Dread(id_, H5T_NATIVE_INT, out_mem, dspace, H5P_DEFAULT, rdata);
+    auto status = H5Dread(id, H5T_NATIVE_INT, out_mem, dspace, H5P_DEFAULT, rdata);
 
     H5Sclose(dspace);
     H5Sclose(out_mem);
-    H5Dclose(id_);
+    H5Dclose(id);
 
     if (status < 0) {
         throw sonata_dataset_exception(name_, (unsigned)i, (unsigned)j);
@@ -250,18 +250,18 @@ auto h5_dataset::double_range(const int i, const int j) {
 
     double rdata[count];
 
-    auto id_ = H5Dopen(parent_id_, name_.c_str(), H5P_DEFAULT);
-    hid_t dspace = H5Dget_space(id_);
+    auto id = H5Dopen(parent_id_, name_.c_str(), H5P_DEFAULT);
+    hid_t dspace = H5Dget_space(id);
 
     hid_t out_mem = H5Screate_simple(1, &dimsm, NULL);
 
     H5Sselect_hyperslab(dspace, H5S_SELECT_SET, &offset, &stride, &count, &block);
 
-    auto status = H5Dread(id_, H5T_NATIVE_DOUBLE, out_mem, dspace, H5P_DEFAULT, rdata);
+    auto status = H5Dread(id, H5T_NATIVE_DOUBLE, out_mem, dspace, H5P_DEFAULT, rdata);
 
     H5Sclose(dspace);
     H5Sclose(out_mem);
-    H5Dclose(id_);
+    H5Dclose(id);
 
     if (status < 0) {
         throw sonata_dataset_exception(name_, (unsigned)i, (unsigned)j);
@@ -285,25 +285,25 @@ auto h5_dataset::int_pair_at(const int i) {
     // Output size
     hsize_t num_elements = 1;
 
-    auto id_ = H5Dopen(parent_id_, name_.c_str(), H5P_DEFAULT);
-    hid_t dspace = H5Dget_space(id_);
+    auto id = H5Dopen(parent_id_, name_.c_str(), H5P_DEFAULT);
+    hid_t dspace = H5Dget_space(id);
 
     H5Sselect_elements(dspace, H5S_SELECT_SET, num_elements, idx_0);
     hid_t out_mem_0 = H5Screate_simple(dims, dim_sizes, NULL);
 
-    auto status0 = H5Dread(id_, H5T_NATIVE_INT, out_mem_0, dspace, H5P_DEFAULT, &out_0);
+    auto status0 = H5Dread(id, H5T_NATIVE_INT, out_mem_0, dspace, H5P_DEFAULT, &out_0);
 
     const hsize_t idx_1[2] = {(hsize_t)i, (hsize_t)1};
 
     H5Sselect_elements(dspace, H5S_SELECT_SET, num_elements, idx_1);
     hid_t out_mem_1 = H5Screate_simple(dims, dim_sizes, NULL);
 
-    auto status1 = H5Dread(id_, H5T_NATIVE_INT, out_mem_1, dspace, H5P_DEFAULT, &out_1);
+    auto status1 = H5Dread(id, H5T_NATIVE_INT, out_mem_1, dspace, H5P_DEFAULT, &out_1);
 
     H5Sclose(dspace);
     H5Sclose(out_mem_0);
     H5Sclose(out_mem_1);
-    H5Dclose(id_);
+    H5Dclose(id);
 
     if (status0 < 0 || status1 < 0) {
         throw sonata_dataset_exception(name_, (unsigned)i);
@@ -314,11 +314,11 @@ auto h5_dataset::int_pair_at(const int i) {
 
 auto h5_dataset::int_1d() {
     int out_a[size_];
-    auto id_ = H5Dopen(parent_id_, name_.c_str(), H5P_DEFAULT);
+    auto id = H5Dopen(parent_id_, name_.c_str(), H5P_DEFAULT);
 
-    auto status = H5Dread(id_, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT,
+    auto status = H5Dread(id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT,
             out_a);
-    H5Dclose(id_);
+    H5Dclose(id);
 
     if (status < 0) {
         throw sonata_dataset_exception(name_);
@@ -331,11 +331,11 @@ auto h5_dataset::int_1d() {
 
 auto h5_dataset::int_2d() {
     int out_a[size_][2];
-    auto id_ = H5Dopen(parent_id_, name_.c_str(), H5P_DEFAULT);
+    auto id = H5Dopen(parent_id_, name_.c_str(), H5P_DEFAULT);
 
-    auto status = H5Dread(id_, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, out_a);
+    auto status = H5Dread(id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, out_a);
 
-    H5Dclose(id_);
+    H5Dclose(id);
 
     if (status < 0) {
         throw sonata_dataset_exception(name_);

--- a/sonata/include/hdf5_lib.hpp
+++ b/sonata/include/hdf5_lib.hpp
@@ -13,7 +13,7 @@ public:
     // Constructor from parent (hdf5 group) id and dataset name - finds size of the dataset
     h5_dataset(hid_t parent, std::string name);
 
-    // Constructor from parent (hdf5 group) id and dataset name - creates int/double dataset with size `size`
+    // Constructor from parent (hdf5 group) id and dataset name - creates andf writes dataset `data`
     h5_dataset(hid_t parent, std::string name, std::vector<int> data);
 
     h5_dataset(hid_t parent, std::string name, std::vector<double> data);

--- a/sonata/include/hdf5_lib.hpp
+++ b/sonata/include/hdf5_lib.hpp
@@ -28,30 +28,17 @@ public:
     // returns number of elements in a dataset
     int size();
 
-    // Read integer at index `i`; throws exception if out of bounds
-    auto int_at(const int i);
+    // Read all dataset
+    template <typename T>
+    auto get();
 
-    // Read double at index `i`; throws exception if out of bounds
-    auto double_at(const int i);
+    // Read at index `i`; throws exception if out of bounds
+    template <typename T>
+    auto get(const int i);
 
-    // Read string at index `i`; throws exception if out of bounds
-    auto string_at(const int i);
-
-    // Read range of integers between indices `i` and `j`; throws exception if out of bounds
-    auto int_range(const int i, const int j);
-
-    // Read range of doubles between indices `i` and `j`; throws exception if out of bounds
-    auto double_range(const int i, const int j);
-
-    // Read integer pair at index `i` (dataset has dimensions size() x 2)
-    // Throws exception if out of bounds
-    auto int_pair_at(const int i);
-
-    // Read all 1D integer dataset
-    auto int_1d();
-
-    // Read all 2D integer dataset
-    auto int_2d();
+    // Read range  between indices `i` and `j`; throws exception if out of bounds
+    template <typename T>
+    auto get(const int i, const int j);
 
 private:
     // id of parent group
@@ -177,29 +164,17 @@ public:
     // Returns size of dataset with name `name`; returns -1 if dataset not found
     int dataset_size(std::string name) const;
 
-    // Returns int at index i of dataset with name `name`; throws exception if dataset not found
-    int int_at(std::string name, unsigned i) const;
+    // Returns value at index i of dataset with name `name`; throws exception if dataset not found
+    template <typename T>
+    T get(std::string name, unsigned i) const;
 
-    // Returns double at index i of dataset with name `name`; throws exception if dataset not found
-    double double_at(std::string name, unsigned i) const;
-
-    // Returns string at index i of dataset with name `name`; throws exception if dataset not found
-    std::string string_at(std::string name, unsigned i) const;
-
-    // Returns integers between indices i and j of dataset with name `name`; throws exception if dataset not found
-    std::vector<int> int_range(std::string name, unsigned i, unsigned j) const;
-
-    // Returns double between indices i and j of dataset with name `name`; throws exception if dataset not found
-    std::vector<double> double_range(std::string name, unsigned i, unsigned j) const;
-
-    // Returns int pair at index i of dataset with name `name`; throws exception if dataset not found
-    std::pair<int, int> int_pair_at(std::string name, unsigned i) const;
+    // Returns values between indices i and j of dataset with name `name`; throws exception if dataset not found
+    template <typename T>
+    T get(std::string name, unsigned i, unsigned j) const;
 
     // Returns full content of 1D dataset with name `name`; throws exception if dataset not found
-    std::vector<int> int_1d(std::string name) const;
-
-    // Returns full content of 2D dataset with name `name`; throws exception if dataset not found
-    std::vector<std::pair<int, int>> int_2d(std::string name) const;
+    template <typename T>
+    T get(std::string name) const;
 
     // Returns h5_wrapper of group at index i in members_
     const h5_wrapper& operator[] (unsigned i) const;

--- a/sonata/include/hdf5_lib.hpp
+++ b/sonata/include/hdf5_lib.hpp
@@ -79,16 +79,8 @@ public:
     std::shared_ptr<h5_group> add_group(std::string name);
 
     // Add a new int dataset
-    void add_dataset(std::string name, std::vector<int> dset);
-
-    // Add a new double dataset
-    void add_dataset(std::string name, std::vector<double> dset);
-
-    // Add a new 2D int dataset
-    void add_dataset(std::string name, std::vector<std::vector<int>> dset);
-
-    // Add a new 2D double dataset
-    void add_dataset(std::string name, std::vector<std::vector<double>> dset);
+    template <typename T>
+    void add_dataset(std::string name, std::vector<T> dset);
 
     // hdf5 groups belonging to group
     std::vector<std::shared_ptr<h5_group>> groups_;

--- a/test/unit/test_hdf5.cpp
+++ b/test/unit/test_hdf5.cpp
@@ -72,6 +72,7 @@ TEST(hdf5_record, verify_nodes) {
 }
 
 TEST(hdf5_record, verify_edges) {
+    using int_pair = std::pair<int,int>;
     std::string datadir{DATADIR};
 
     auto filename0 = datadir + "/edges_0.h5";
@@ -112,16 +113,16 @@ TEST(hdf5_record, verify_edges) {
     EXPECT_EQ(r[3].name(), r["pop_ext_e"].name());
 
     EXPECT_EQ(2, r["pop_e_i"].dataset_size("edge_group_id"));
-    EXPECT_EQ(0, r["pop_e_i"].int_at("edge_group_id",0));
-    EXPECT_EQ(1, r["pop_e_i"].int_at("edge_group_id",1));
+    EXPECT_EQ(0, r["pop_e_i"].get<int>("edge_group_id",0));
+    EXPECT_EQ(1, r["pop_e_i"].get<int>("edge_group_id",1));
 
     EXPECT_EQ(2, r["pop_e_i"].dataset_size("edge_group_index"));
-    EXPECT_EQ(0, r["pop_e_i"].int_at("edge_group_index",0));
-    EXPECT_EQ(0, r["pop_e_i"].int_at("edge_group_index",1));
+    EXPECT_EQ(0, r["pop_e_i"].get<int>("edge_group_index",0));
+    EXPECT_EQ(0, r["pop_e_i"].get<int>("edge_group_index",1));
 
     EXPECT_EQ(2, r["pop_e_i"].dataset_size("edge_type_id"));
-    EXPECT_EQ(103, r["pop_e_i"].int_at("edge_type_id",0));
-    EXPECT_EQ(103, r["pop_e_i"].int_at("edge_type_id",1));
+    EXPECT_EQ(103, r["pop_e_i"].get<int>("edge_type_id",0));
+    EXPECT_EQ(103, r["pop_e_i"].get<int>("edge_type_id",1));
 
     EXPECT_NE(-1, r["pop_e_i"].find_group("0"));
     EXPECT_NE(-1, r["pop_e_i"].find_group("1"));
@@ -132,36 +133,36 @@ TEST(hdf5_record, verify_edges) {
     EXPECT_NE(-1, r["pop_e_e"].find_group("0"));
     EXPECT_EQ(-1, r["pop_e_e"].find_group("1"));
 
-    EXPECT_EQ(0,   r["pop_e_i"]["0"].int_at("afferent_section_id", 0));
-    EXPECT_NEAR(0.4, r["pop_e_i"]["0"].double_at("afferent_section_pos", 0), 1e-5);
-    EXPECT_EQ(1,   r["pop_e_i"]["0"].int_at("efferent_section_id", 0));
-    EXPECT_NEAR(0.3, r["pop_e_i"]["0"].double_at("efferent_section_pos", 0), 1e-5);
+    EXPECT_EQ(0,   r["pop_e_i"]["0"].get<int>("afferent_section_id", 0));
+    EXPECT_NEAR(0.4, r["pop_e_i"]["0"].get<double>("afferent_section_pos", 0), 1e-5);
+    EXPECT_EQ(1,   r["pop_e_i"]["0"].get<int>("efferent_section_id", 0));
+    EXPECT_NEAR(0.3, r["pop_e_i"]["0"].get<double>("efferent_section_pos", 0), 1e-5);
 
-    EXPECT_EQ(2,   r["pop_e_i"]["1"].int_at("afferent_section_id", 0));
-    EXPECT_NEAR(0.1, r["pop_e_i"]["1"].double_at("afferent_section_pos", 0), 1e-5);
-    EXPECT_EQ(3,   r["pop_e_i"]["1"].int_at("efferent_section_id", 0));
-    EXPECT_NEAR(0.2, r["pop_e_i"]["1"].double_at("efferent_section_pos", 0), 1e-5);
+    EXPECT_EQ(2,   r["pop_e_i"]["1"].get<int>("afferent_section_id", 0));
+    EXPECT_NEAR(0.1, r["pop_e_i"]["1"].get<double>("afferent_section_pos", 0), 1e-5);
+    EXPECT_EQ(3,   r["pop_e_i"]["1"].get<int>("efferent_section_id", 0));
+    EXPECT_NEAR(0.2, r["pop_e_i"]["1"].get<double>("efferent_section_pos", 0), 1e-5);
 
-    EXPECT_EQ(0,   r["pop_i_e"]["0"].int_at("afferent_section_id", 0));
-    EXPECT_NEAR(0.5, r["pop_i_e"]["0"].double_at("afferent_section_pos", 0), 1e-5);
-    EXPECT_EQ(0,   r["pop_i_e"]["0"].int_at("efferent_section_id", 0));
-    EXPECT_NEAR(0.9, r["pop_i_e"]["0"].double_at("efferent_section_pos", 0), 1e-5);
+    EXPECT_EQ(0,   r["pop_i_e"]["0"].get<int>("afferent_section_id", 0));
+    EXPECT_NEAR(0.5, r["pop_i_e"]["0"].get<double>("afferent_section_pos", 0), 1e-5);
+    EXPECT_EQ(0,   r["pop_i_e"]["0"].get<int>("efferent_section_id", 0));
+    EXPECT_NEAR(0.9, r["pop_i_e"]["0"].get<double>("efferent_section_pos", 0), 1e-5);
 
-    EXPECT_EQ(5,   r["pop_e_e"]["0"].int_at("afferent_section_id", 0));
-    EXPECT_NEAR(0.6, r["pop_e_e"]["0"].double_at("afferent_section_pos", 0), 1e-5);
-    EXPECT_EQ(1,   r["pop_e_e"]["0"].int_at("efferent_section_id", 0));
-    EXPECT_NEAR(0.2, r["pop_e_e"]["0"].double_at("efferent_section_pos", 0), 1e-5);
+    EXPECT_EQ(5,   r["pop_e_e"]["0"].get<int>("afferent_section_id", 0));
+    EXPECT_NEAR(0.6, r["pop_e_e"]["0"].get<double>("afferent_section_pos", 0), 1e-5);
+    EXPECT_EQ(1,   r["pop_e_e"]["0"].get<int>("efferent_section_id", 0));
+    EXPECT_NEAR(0.2, r["pop_e_e"]["0"].get<double>("efferent_section_pos", 0), 1e-5);
 
-    EXPECT_EQ(std::make_pair(0,1), r["pop_e_i"]["indicies"]["source_to_target"].int_pair_at("node_id_to_ranges", 0));
-    EXPECT_EQ(std::make_pair(1,1), r["pop_e_i"]["indicies"]["source_to_target"].int_pair_at("node_id_to_ranges", 1));
-    EXPECT_EQ(std::make_pair(1,2), r["pop_e_i"]["indicies"]["source_to_target"].int_pair_at("node_id_to_ranges", 2));
-    EXPECT_EQ(std::make_pair(2,2), r["pop_e_i"]["indicies"]["source_to_target"].int_pair_at("node_id_to_ranges", 3));
+    EXPECT_EQ(std::make_pair(0,1), r["pop_e_i"]["indicies"]["source_to_target"].get<int_pair>("node_id_to_ranges", 0));
+    EXPECT_EQ(std::make_pair(1,1), r["pop_e_i"]["indicies"]["source_to_target"].get<int_pair>("node_id_to_ranges", 1));
+    EXPECT_EQ(std::make_pair(1,2), r["pop_e_i"]["indicies"]["source_to_target"].get<int_pair>("node_id_to_ranges", 2));
+    EXPECT_EQ(std::make_pair(2,2), r["pop_e_i"]["indicies"]["source_to_target"].get<int_pair>("node_id_to_ranges", 3));
 
-    EXPECT_EQ(std::make_pair(0,1), r["pop_e_i"]["indicies"]["source_to_target"].int_pair_at("range_to_edge_id", 0));
-    EXPECT_EQ(std::make_pair(1,2), r["pop_e_i"]["indicies"]["source_to_target"].int_pair_at("range_to_edge_id", 1));
+    EXPECT_EQ(std::make_pair(0,1), r["pop_e_i"]["indicies"]["source_to_target"].get<int_pair>("range_to_edge_id", 0));
+    EXPECT_EQ(std::make_pair(1,2), r["pop_e_i"]["indicies"]["source_to_target"].get<int_pair>("range_to_edge_id", 1));
 
-    EXPECT_EQ(0, r["pop_e_i"].int_at("source_node_id", 0));
-    EXPECT_EQ(0, r["pop_e_i"].int_at("target_node_id", 0));
-    EXPECT_EQ(2, r["pop_e_i"].int_at("source_node_id", 1));
-    EXPECT_EQ(0, r["pop_e_i"].int_at("target_node_id", 1));
+    EXPECT_EQ(0, r["pop_e_i"].get<int>("source_node_id", 0));
+    EXPECT_EQ(0, r["pop_e_i"].get<int>("target_node_id", 0));
+    EXPECT_EQ(2, r["pop_e_i"].get<int>("source_node_id", 1));
+    EXPECT_EQ(0, r["pop_e_i"].get<int>("target_node_id", 1));
 }


### PR DESCRIPTION
Previously, the hdf5 wrappers in `hdf5_lib` were only for querying the files, now we can create new files, groups and datasets as part of the same interface. This simplifies the code in `sonata_io`. 
Use one templated function to read int/double/pair/vector etc from hdf5 files instead many individual functions. 
Fix unit tests
 